### PR TITLE
acl: an ACL parser and evaluator

### DIFF
--- a/acl/acl.go
+++ b/acl/acl.go
@@ -1,0 +1,220 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Package acl implements ACL evaluation for access to a secrets
+// database.
+//
+// ACL policy files are a HuJSON object that looks like:
+//
+//	{
+//	  "groups": {
+//	    "admins": ["dave@tailscale.com", "kylie@tailscale.com", "fromberger@tailscale.com"],
+//	    "log-sources": ["tag:server", "tag:lab"],
+//	  },
+//	  "rules": [
+//	    {
+//	      "principal": ["tag:control", "tag:control-us"],
+//	      "action": ["get"],
+//	      "secret": ["prod/control/rudderstack-api-key", "prod/control/stripe-api-key"],
+//	    },
+//	    {
+//	      "principal": ["group:log-sources", "kylie@tailscale.com"],
+//	      "action": ["get"],
+//	      "secret": ["prod/elastic-agent-authkey"],
+//	    },
+//	    {
+//	      "principal": ["group:admins"],
+//	      "action": ["get", "list", "put", "set-active", "delete"],
+//	      "secret": ["*"],
+//	    },
+//	    {
+//	      "principal": ["dave@tailscale.com"],
+//	      "action": ["get", "list", "put", "set-active", "delete"],
+//	      "secret": ["dev/*", "prod/*/some-secret"],
+//	    },
+//	  ],
+//	}
+package acl
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/tailscale/hujson"
+	"tailscale.com/util/multierr"
+)
+
+// Action is an action on secrets that is subject to access control.
+type Action string
+
+const (
+	ActionGet       = Action("get")
+	ActionList      = Action("list")
+	ActionPut       = Action("put")
+	ActionSetActive = Action("set-active")
+	ActionDelete    = Action("delete")
+)
+
+// Policy is an ACL policy that controls access to secrets.
+type Policy struct {
+	groups map[string][]string
+	rules  []compiledRule
+}
+
+// Compile returns a Policy that enforces the ACLs in bs.
+func Compile(bs []byte) (*Policy, error) {
+	bs, err := hujson.Standardize(bs)
+	if err != nil {
+		return nil, fmt.Errorf("converting ACL policy to JSON: %w", err)
+	}
+
+	type rule struct {
+		From   []string `json:"principal"`
+		Secret []string `json:"secret"`
+		Action []Action `json:"action"`
+	}
+	var pol struct {
+		Groups map[string][]string `json:"groups"`
+		Rules  []rule              `json:"rules"`
+	}
+	dec := json.NewDecoder(bytes.NewBuffer(bs))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&pol); err != nil {
+		return nil, fmt.Errorf("parsing ACL policy JSON: %w", err)
+	}
+
+	ret := &Policy{
+		groups: pol.Groups,
+	}
+	var errs []error
+
+	for i, r := range pol.Rules {
+		ruleNum := i + 1
+
+		from, err := expandFrom(ruleNum, r.From, ret.groups)
+		if err != nil {
+			errs = append(errs, err)
+		}
+		secret, err := expandSecret(ruleNum, r.Secret)
+		if err != nil {
+			errs = append(errs, err)
+		}
+		action, err := expandAction(ruleNum, r.Action)
+		if err != nil {
+			errs = append(errs, err)
+		}
+		ret.rules = append(ret.rules, compiledRule{from, secret, action})
+	}
+
+	if len(errs) > 0 {
+		return nil, multierr.New(errs...)
+	}
+	return ret, nil
+}
+
+// Allow reports whether anyone in 'from' can perform 'action' on 'secret'.
+func (p *Policy) Allow(from []string, secret string, action Action) bool {
+	for _, r := range p.rules {
+		if r.allow(from, secret, action) {
+			return true
+		}
+	}
+	return false
+}
+
+type compiledRule struct {
+	from   map[string]bool
+	secret *regexp.Regexp
+	action map[Action]bool
+}
+
+func (r *compiledRule) allow(from []string, secret string, action Action) bool {
+	if !r.action[action] {
+		return false
+	}
+	if !r.secret.MatchString(secret) {
+		return false
+	}
+	for _, f := range from {
+		if r.from[f] {
+			return true
+		}
+	}
+	return false
+}
+
+// expandFrom converts from into a map for fast lookups. Elements of
+// the form "group:..." are expanded to the group's members.
+func expandFrom(ruleNum int, from []string, groups map[string][]string) (map[string]bool, error) {
+	ret := map[string]bool{}
+	var errs []error
+	for _, f := range from {
+		g, ok := strings.CutPrefix(f, "group:")
+		if !ok {
+			ret[f] = true
+			continue
+		}
+
+		grp, ok := groups[g]
+		if !ok {
+			errs = append(errs, fmt.Errorf("rule %d references unknown group %q", ruleNum, g))
+			continue
+		}
+		for _, gf := range grp {
+			ret[gf] = true
+		}
+	}
+	if len(errs) > 0 {
+		return nil, multierr.New(errs...)
+	}
+	return ret, nil
+}
+
+// expandSecret converts secret into a regular expression for fast
+// matching.
+func expandSecret(ruleNum int, secret []string) (*regexp.Regexp, error) {
+	var ret []string
+	// We want the user to use glob-ish syntax, where '*' is the
+	// equivalent of regexp's '.*'. We also don't want any other
+	// character of the input misinterpreted as a regexp control
+	// character.
+	//
+	// To achieve this, we:
+	//  - split each input string on '*'
+	//  - regexp-quote the resulting parts
+	//  - reassemble the quoted parts around '.*' separators
+	//  - join all the converted inputs together with '|'
+	//
+	// The result is a single regex that expresses "any of the forms
+	// in secret", with our desired glob-ish wildcard.
+	for _, s := range secret {
+		parts := strings.Split(s, "*")
+		for i := range parts {
+			parts[i] = regexp.QuoteMeta(parts[i])
+		}
+		ret = append(ret, strings.Join(parts, ".*"))
+	}
+	reStr := fmt.Sprintf("^(?:%s)$", strings.Join(ret, "|"))
+	return regexp.Compile(reStr)
+}
+
+// expandAction converts action into a map for fast lookups.
+func expandAction(ruleNum int, action []Action) (map[Action]bool, error) {
+	ret := map[Action]bool{}
+	var errs []error
+	for _, a := range action {
+		switch a {
+		case ActionGet, ActionList, ActionPut, ActionSetActive, ActionDelete:
+			ret[a] = true
+		default:
+			errs = append(errs, fmt.Errorf("rule %d has unknown action %q", ruleNum, a))
+		}
+	}
+	if len(errs) > 0 {
+		return nil, multierr.New(errs...)
+	}
+	return ret, nil
+}

--- a/acl/acl_test.go
+++ b/acl/acl_test.go
@@ -1,0 +1,134 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package acl_test
+
+import (
+	"testing"
+
+	"github.com/tailscale/setec/acl"
+)
+
+func TestACL(t *testing.T) {
+	const src = `
+{
+  "groups": {
+    "admins": ["a@ts.net", "b@ts.net"],
+    "servers": ["tag:server", "tag:lab"],
+  },
+  "rules": [
+    {
+      "principal": ["tag:control"],
+      "action": ["get"],
+      "secret": ["control/foo", "control/bar"],
+    },
+    {
+      "principal": ["group:servers", "c@ts.net"],
+      "action": ["get"],
+      "secret": ["quux"],
+    },
+    {
+      "principal": ["group:admins"],
+      "action": ["get", "list", "put", "set-active", "delete"],
+      "secret": ["*"],
+    },
+    {
+      "principal": ["c@ts.net"],
+      "action": ["get", "list", "put", "set-active", "delete"],
+      "secret": ["dev/*", "prod/*/some-secret"],
+    },
+  ],
+}`
+	pol, err := acl.Compile([]byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type testCase struct {
+		from   []string
+		secret string
+		action acl.Action
+		want   bool
+	}
+	allow := func(action, secret string, from ...string) testCase {
+		return testCase{from, secret, acl.Action(action), true}
+	}
+	deny := func(action, secret string, from ...string) testCase {
+		return testCase{from, secret, acl.Action(action), false}
+	}
+	tests := []testCase{
+		allow("get", "control/foo", "tag:control"),
+		allow("get", "control/foo", "tag:other", "tag:control"),
+		allow("get", "control/bar", "tag:control"),
+		deny("get", "control/quux", "tag:control"),
+		deny("get", "control/foo", "tag:other"),
+		deny("list", "control/foo", "tag:control"),
+		deny("put", "control/foo", "tag:control"),
+		deny("set-active", "control/foo", "tag:control"),
+		deny("delete", "control/foo", "tag:control"),
+		deny("put", "control/other", "tag:control"),
+
+		allow("get", "quux", "tag:server"),
+		allow("get", "quux", "tag:lab"),
+		allow("get", "quux", "tag:other", "tag:lab"),
+		allow("get", "quux", "tag:other", "tag:server", "tag:lab"),
+		allow("get", "quux", "c@ts.net"),
+		deny("put", "quux", "c@ts.net"),
+		deny("put", "quux", "tag:server"),
+		deny("put", "quux", "tag:other"),
+
+		allow("get", "control/foo", "a@ts.net"),
+		allow("put", "control/foo", "b@ts.net"),
+		allow("list", "quux", "b@ts.net"),
+		allow("set-active", "quux", "b@ts.net"),
+		allow("delete", "quux", "b@ts.net"),
+
+		allow("get", "dev/foo", "c@ts.net"),
+		allow("put", "dev/foo", "c@ts.net"),
+		allow("list", "dev/bar", "c@ts.net"),
+		allow("set-active", "dev/bar", "c@ts.net"),
+		allow("delete", "dev/bar", "c@ts.net"),
+		allow("get", "prod/foo/some-secret", "c@ts.net"),
+		allow("put", "prod/foo/some-secret", "c@ts.net"),
+		allow("list", "prod/quux/some-secret", "c@ts.net"),
+		allow("set-active", "prod/other/some-secret", "c@ts.net"),
+		allow("delete", "prod/wat/some-secret", "c@ts.net"),
+		deny("get", "prod/other/suffix", "c@ts.net"),
+		deny("get", "prod/some-secret", "c@ts.net"),
+	}
+
+	for _, test := range tests {
+		if got := pol.Allow(test.from, test.secret, test.action); got != test.want {
+			t.Errorf("Allow(%v, %q, %q) = %v, want %v", test.from, test.secret, test.action, got, test.want)
+		}
+	}
+}
+
+func TestInvalidPolicy(t *testing.T) {
+	reject := map[string]string{
+		"gibberish":        `gthgoht34h89`,
+		"unknown-field":    `{"blork": 42}`,
+		"wrong-group-type": `{"groups": "I'm a little teapot"}`,
+		"wrong-rules-type": `{"rules": "short and stout"}`,
+		"missing-group": `{
+  "rules": [{
+    "action": ["get"],
+    "secret": ["*"],
+    "principal": ["group:missing"],
+  }]
+}`,
+		"unknown-action": `{
+  "rules": [{
+    "action": ["oscillate-the-overthruster"],
+    "secret": ["*"],
+    "principal": ["a@ts.net"],
+  }]
+}`,
+	}
+
+	for n, r := range reject {
+		if _, err := acl.Compile([]byte(r)); err == nil {
+			t.Errorf("parse %q succeeded, want error", n)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/tailscale/setec
 
 go 1.20
 
-require tailscale.com v1.1.1-0.20230720005356-efd6d90dd719
+require (
+	github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a
+	tailscale.com v1.1.1-0.20230720005356-efd6d90dd719
+)
 
 require (
 	filippo.io/edwards25519 v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -168,6 +168,8 @@ github.com/tailscale/golang-x-crypto v0.0.0-20230713185742-f0b76a10a08e h1:JyeJF
 github.com/tailscale/golang-x-crypto v0.0.0-20230713185742-f0b76a10a08e/go.mod h1:DjoeCULdP6vTJ/xY+nzzR9LaUHprkbZEpNidX0aqEEk=
 github.com/tailscale/goupnp v1.0.1-0.20210804011211-c64d0f06ea05 h1:4chzWmimtJPxRs2O36yuGRW3f9SYV+bMTTvMBI0EKio=
 github.com/tailscale/goupnp v1.0.1-0.20210804011211-c64d0f06ea05/go.mod h1:PdCqy9JzfWMJf1H5UJW2ip33/d4YkoKN0r67yKH1mG8=
+github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a h1:SJy1Pu0eH1C29XwJucQo73FrleVK6t4kYz4NVhp34Yw=
+github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a/go.mod h1:DFSS3NAGHthKo1gTlmEcSBiZrRJXi28rLNd/1udP1c8=
 github.com/tailscale/netlink v1.1.1-0.20211101221916-cabfb018fe85 h1:zrsUcqrG2uQSPhaUPjUQwozcRdDdSxxqhNgNZ3drZFk=
 github.com/tailscale/netlink v1.1.1-0.20211101221916-cabfb018fe85/go.mod h1:NzVQi3Mleb+qzq8VmcWpSkcSYxXIg0DkI6XDzpVkhJ0=
 github.com/tailscale/wireguard-go v0.0.0-20230710185534-bb2c8f22eccf h1:bHQHwIHId353jAF2Lm0cGDjJpse/PYS0I0DTtihL9Ls=


### PR DESCRIPTION
Updates tailscale/corp#13375

---

I believe this implements the semantics as specified in the design doc. I threw in support for groups, since it was easy to do and I suspect we'll end up wanting it sooner than later.