### PR TITLE
cmd/setec: add 'server' subcommand that can run in dev mode

### DIFF
--- a/cmd/setec/setec.go
+++ b/cmd/setec/setec.go
@@ -6,38 +6,123 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"path/filepath"
 
+	"github.com/peterbourgon/ff/v3/ffcli"
+	"github.com/tailscale/setec/server"
+	"github.com/tink-crypto/tink-go/v2/testutil"
+	"github.com/tink-crypto/tink-go/v2/tink"
 	"tailscale.com/tsnet"
 	"tailscale.com/tsweb"
 )
 
-var (
-	stateDir = flag.String("state-dir", "", "tsnet state dir")
-	hostname = flag.String("hostname", "setec-dev", "Tailscale hostname to use")
-)
-
 func main() {
-	flag.Parse()
-	if *stateDir == "" {
-		log.Fatal("--state-dir must be specified")
+	serverCmd := &ffcli.Command{
+		Name:      "server",
+		ShortHelp: "run the setec server",
+		FlagSet: func() *flag.FlagSet {
+			fs := flag.NewFlagSet("server", flag.ExitOnError)
+			fs.StringVar(&serverArgs.StateDir, "state-dir", "", "tsnet state dir")
+			fs.StringVar(&serverArgs.Hostname, "hostname", "", "Tailscale hostname to use")
+			fs.StringVar(&serverArgs.KMSKeyName, "kms-key-name", "", "name of KMS key to use for database encryption")
+			fs.BoolVar(&serverArgs.Dev, "dev", false, "dev mode")
+			return fs
+		}(),
+		Exec: runServer,
+	}
+
+	root := &ffcli.Command{
+		Name:        "setec",
+		Subcommands: []*ffcli.Command{serverCmd},
+		Exec:        func(context.Context, []string) error { return flag.ErrHelp },
+	}
+
+	if err := root.ParseAndRun(context.Background(), os.Args[1:]); err != nil {
+		log.Fatal(err)
+	}
+}
+
+var serverArgs struct {
+	StateDir   string
+	Hostname   string
+	KMSKeyName string
+	Dev        bool
+}
+
+func runServer(ctx context.Context, args []string) error {
+	if len(args) > 0 {
+		return errors.New("unexpected extra positional arguments")
+	}
+
+	var kek tink.AEAD
+	if serverArgs.Dev {
+		if serverArgs.StateDir == "" {
+			const devState = "setec-dev.state"
+			if err := os.MkdirAll(devState, 0700); err != nil {
+				return fmt.Errorf("creating dev state dir %q: %w", devState, err)
+			}
+			serverArgs.StateDir = devState
+		}
+		if serverArgs.Hostname == "" {
+			serverArgs.Hostname = "setec-dev"
+		}
+		if serverArgs.KMSKeyName == "" {
+			kek = &testutil.DummyAEAD{
+				Name: "SetecDevOnlyDummyEncryption",
+			}
+		}
+		log.Printf("dev mode: state dir is %q", serverArgs.StateDir)
+		log.Printf("dev mode: hostname is %q", serverArgs.Hostname)
+		log.Println("dev mode: using dummy KMS, NOT SAFE FOR PRODUCTION USE")
+	}
+
+	if serverArgs.StateDir == "" {
+		return errors.New("--state-dir must be specified")
+	}
+	if serverArgs.Hostname == "" {
+		return errors.New("--hostname must be specified")
+	}
+	if kek == nil {
+		if serverArgs.KMSKeyName == "" {
+			return errors.New("--kms-key-name must be specified")
+		}
+		// TODO(corp/13375): hook up to cloud KMS, and have a --dev mode.
+		return errors.New("TODO: hookup to AWS KMS not implemented yet.")
 	}
 
 	s := &tsnet.Server{
-		Dir:      filepath.Join(*stateDir, "tsnet"),
-		Hostname: *hostname,
+		Dir:      filepath.Join(serverArgs.StateDir, "tsnet"),
+		Hostname: serverArgs.Hostname,
+	}
+
+	lc, err := s.LocalClient()
+	if err != nil {
+		return fmt.Errorf("getting tailscale localapi client: %v", err)
 	}
 
 	mux := http.NewServeMux()
 	tsweb.Debugger(mux)
 
+	_, err = server.New(server.Config{
+		DBPath: filepath.Join(serverArgs.StateDir, "database"),
+		Key:    kek,
+		WhoIs:  lc.WhoIs,
+		Mux:    mux,
+	})
+	if err != nil {
+		return fmt.Errorf("initializing setec server: %v", err)
+	}
+
 	l80, err := s.Listen("tcp", ":80")
 	if err != nil {
-		log.Fatalf("creating HTTP listener: %v", err)
+		return fmt.Errorf("creating HTTP listener: %v", err)
 	}
 	go func() {
 		if err := http.Serve(l80, tsweb.Port80Handler{Main: mux}); err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -47,9 +132,11 @@ func main() {
 
 	l, err := s.ListenTLS("tcp", ":443")
 	if err != nil {
-		log.Fatalf("creating TLS listener: %v", err)
+		return fmt.Errorf("creating TLS listener: %v", err)
 	}
 	if err := http.Serve(l, tsweb.BrowserHeaderHandler(mux)); err != nil && !errors.Is(err, http.ErrServerClosed) {
-		log.Fatalf("serving HTTPS: %v", err)
+		return fmt.Errorf("serving HTTPS: %v", err)
 	}
+
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/google/go-cmp v0.5.9
+	github.com/peterbourgon/ff/v3 v3.3.0
 	github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a
 	github.com/tink-crypto/tink-go/v2 v2.0.0
 	golang.org/x/exp v0.0.0-20230725093048-515e97ebf090

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
+github.com/peterbourgon/ff/v3 v3.3.0 h1:PaKe7GW8orVFh8Unb5jNHS+JZBwWUMa2se0HM6/BI24=
+github.com/peterbourgon/ff/v3 v3.3.0/go.mod h1:zjJVUhx+twciwfDl0zBcFzl4dW8axCRyXE/eKY9RztQ=
 github.com/pierrec/lz4/v4 v4.1.14/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pierrec/lz4/v4 v4.1.17 h1:kV4Ip+/hUBC+8T6+2EgburRtkE9ef4nbY3f4dFhGjMc=
 github.com/pierrec/lz4/v4 v4.1.17/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=


### PR DESCRIPTION
Currently can only run in dev mode, since KMS integration for database encryption is still missing.

Updates tailscale/corp#13375