### PR TITLE
db: disallow Put with an empty secret name

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -166,7 +166,8 @@ func (db *DB) Put(name string, value []byte, from []string) (api.SecretVersion, 
 	defer db.mu.Unlock()
 	if name == "" {
 		return 0, errors.New("empty secret name")
-	} else if !db.checkACLLocked(from, name, acl.ActionPut) {
+	}
+	if !db.checkACLLocked(from, name, acl.ActionPut) {
 		return 0, ErrAccessDenied
 	}
 

--- a/db/db.go
+++ b/db/db.go
@@ -164,7 +164,9 @@ func (db *DB) GetVersion(name string, version api.SecretVersion, from []string) 
 func (db *DB) Put(name string, value []byte, from []string) (api.SecretVersion, error) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
-	if !db.checkACLLocked(from, name, acl.ActionPut) {
+	if name == "" {
+		return 0, errors.New("empty secret name")
+	} else if !db.checkACLLocked(from, name, acl.ActionPut) {
 		return 0, ErrAccessDenied
 	}
 
@@ -202,7 +204,9 @@ func (db *DB) putConfigLocked(name string, value []byte) (api.SecretVersion, err
 func (db *DB) SetActiveVersion(name string, version api.SecretVersion, from []string) error {
 	db.mu.Lock()
 	defer db.mu.Unlock()
-	if !db.checkACLLocked(from, name, acl.ActionSetActive) {
+	if name == "" {
+		return errors.New("empty secret name")
+	} else if !db.checkACLLocked(from, name, acl.ActionSetActive) {
 		return ErrAccessDenied
 	}
 

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -69,6 +69,9 @@ func TestNoACLNoService(t *testing.T) {
 	if _, err := d.GetVersion("test", 42, from); !errors.Is(err, db.ErrAccessDenied) {
 		t.Fatal("GetVersion with no ACLs did not error")
 	}
+	if v, err := d.Put("", []byte("ouch"), from); err == nil {
+		t.Fatalf("Put with empty secret name: got %+v, want error", v)
+	}
 	if _, err := d.Put("test", []byte("123"), from); !errors.Is(err, db.ErrAccessDenied) {
 		t.Fatal("Put with no ACLs did not error")
 	}


### PR DESCRIPTION
Although we can certainly store an empty secret name, an empty name is likely
either a programming error, or someone trying to be too clever.

We can always relax the constraint later if we want. For now, make the DB
enforce non-empty names when secrets are Put.
