### PR TITLE
cmd/setec: implement a basic CLI to manage secrets

### DIFF
--- a/client/setec/client.go
+++ b/client/setec/client.go
@@ -105,7 +105,12 @@ func do[RESP, REQ any](ctx context.Context, c *Client, path string, req REQ) (RE
 		if err != nil {
 			return resp, fmt.Errorf("reading error response body (HTTP status %d): %w", httpResp.StatusCode, err)
 		}
-		return resp, fmt.Errorf("request returned status %d: %q", httpResp.StatusCode, string(errBs))
+		return resp, fmt.Errorf("request returned status %d: %q", httpResp.StatusCode, string(bytes.TrimSpace(errBs)))
+	}
+
+	bs, err = io.ReadAll(httpResp.Body)
+	if err != nil {
+		return resp, err
 	}
 
 	if err := json.Unmarshal(bs, &resp); err != nil {

--- a/cmd/setec/setec.go
+++ b/cmd/setec/setec.go
@@ -6,27 +6,36 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
+	"text/tabwriter"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
+	"github.com/tailscale/setec/client/setec"
 	"github.com/tailscale/setec/server"
+	"github.com/tailscale/setec/types/api"
 	"github.com/tink-crypto/tink-go/v2/testutil"
 	"github.com/tink-crypto/tink-go/v2/tink"
+	"golang.org/x/term"
 	"tailscale.com/tsnet"
 	"tailscale.com/tsweb"
 )
 
 func main() {
 	serverCmd := &ffcli.Command{
-		Name:      "server",
-		ShortHelp: "run the setec server",
+		Name:       "server",
+		ShortUsage: "setec server [flags]",
+		ShortHelp:  "run the setec server",
 		FlagSet: func() *flag.FlagSet {
 			fs := flag.NewFlagSet("server", flag.ExitOnError)
 			fs.StringVar(&serverArgs.StateDir, "state-dir", "", "tsnet state dir")
@@ -37,14 +46,61 @@ func main() {
 		}(),
 		Exec: runServer,
 	}
-
-	root := &ffcli.Command{
-		Name:        "setec",
-		Subcommands: []*ffcli.Command{serverCmd},
-		Exec:        func(context.Context, []string) error { return flag.ErrHelp },
+	listCmd := &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "setec list [flags] <server>",
+		ShortHelp:  "list secrets",
+		Exec:       runList,
+	}
+	getCmd := &ffcli.Command{
+		Name:       "get",
+		ShortUsage: "setec get [flags] <server> <secret-name>",
+		ShortHelp:  "get a secret",
+		FlagSet: func() *flag.FlagSet {
+			fs := flag.NewFlagSet("get", flag.ExitOnError)
+			fs.Uint64Var(&getArgs.Version, "version", 0, "secret version to retrieve (default: the active version)")
+			return fs
+		}(),
+		Exec: runGet,
+	}
+	putCmd := &ffcli.Command{
+		Name:       "put",
+		ShortUsage: "setec put [flags] <server> <secret-name>",
+		ShortHelp:  "put a secret",
+		FlagSet: func() *flag.FlagSet {
+			fs := flag.NewFlagSet("put", flag.ExitOnError)
+			fs.StringVar(&putArgs.File, "from-file", "", "read secret value from file instead of prompting interactively")
+			return fs
+		}(),
+		Exec: runPut,
+	}
+	setActiveCmd := &ffcli.Command{
+		Name:       "activate",
+		ShortUsage: "setec activate [flags] <server> <secret-name> <secret-version>",
+		ShortHelp:  "activate a secret version",
+		Exec:       runSetActive,
 	}
 
-	if err := root.ParseAndRun(context.Background(), os.Args[1:]); err != nil {
+	root := &ffcli.Command{
+		Name:       "setec",
+		ShortUsage: "setec <subcmd>",
+		Subcommands: []*ffcli.Command{
+			serverCmd,
+			listCmd,
+			getCmd,
+			putCmd,
+			setActiveCmd,
+		},
+		Exec: func(context.Context, []string) error { return flag.ErrHelp },
+	}
+
+	if err := root.ParseAndRun(context.Background(), os.Args[1:]); errors.Is(err, flag.ErrHelp) {
+		// A command tried to run but instructed us to print
+		// help. Exit unsuccessfully to convey that the intended
+		// command didn't run. Note, this branch isn't taken when the
+		// user requests --help explicitly.
+		os.Exit(2)
+	} else if err != nil {
 		log.Fatal(err)
 	}
 }
@@ -58,7 +114,7 @@ var serverArgs struct {
 
 func runServer(ctx context.Context, args []string) error {
 	if len(args) > 0 {
-		return errors.New("unexpected extra positional arguments")
+		return flag.ErrHelp
 	}
 
 	var kek tink.AEAD
@@ -94,7 +150,7 @@ func runServer(ctx context.Context, args []string) error {
 			return errors.New("--kms-key-name must be specified")
 		}
 		// TODO(corp/13375): hook up to cloud KMS, and have a --dev mode.
-		return errors.New("TODO: hookup to AWS KMS not implemented yet")
+		return errors.New("todo: hookup to AWS KMS not implemented yet")
 	}
 
 	s := &tsnet.Server{
@@ -106,6 +162,17 @@ func runServer(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("getting tailscale localapi client: %v", err)
 	}
+
+	// Wait until tailscale is fully up, so that CertDomains has data.
+	if _, err := s.Up(context.Background()); err != nil {
+		return fmt.Errorf("tailscale did not come up: %w", err)
+	}
+
+	doms := s.CertDomains()
+	if len(doms) == 0 {
+		return fmt.Errorf("tailscale did not provide TLS domains")
+	}
+	fqdn := doms[0]
 
 	mux := http.NewServeMux()
 	tsweb.Debugger(mux)
@@ -125,7 +192,11 @@ func runServer(ctx context.Context, args []string) error {
 		return fmt.Errorf("creating HTTP listener: %v", err)
 	}
 	go func() {
-		if err := http.Serve(l80, tsweb.Port80Handler{Main: mux}); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		port80 := tsweb.Port80Handler{
+			Main: mux,
+			FQDN: fqdn,
+		}
+		if err := http.Serve(l80, port80); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Fatalf("serving HTTP: %v", err)
 		}
 	}()
@@ -136,6 +207,154 @@ func runServer(ctx context.Context, args []string) error {
 	}
 	if err := http.Serve(l, tsweb.BrowserHeaderHandler(mux)); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return fmt.Errorf("serving HTTPS: %v", err)
+	}
+
+	return nil
+}
+
+func clientFromArgs(args []string) (client *setec.Client, remainingArgs []string, err error) {
+	if len(args) < 1 {
+		return nil, nil, flag.ErrHelp
+	}
+	server := args[0]
+	// TODO(corp/13375): make a better UX here where single-label
+	// hostnames get expanded into a full HTTPS URL.
+	return &setec.Client{
+		Server: server,
+	}, args[1:], nil
+}
+
+func runList(ctx context.Context, args []string) error {
+	c, args, err := clientFromArgs(args)
+	if err != nil {
+		return err
+	}
+	if len(args) > 0 {
+		return flag.ErrHelp
+	}
+
+	secrets, err := c.List(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list secrets: %v", err)
+	}
+
+	tw := tabwriter.NewWriter(os.Stdout, 0, 8, 0, '\t', 0)
+	io.WriteString(tw, "NAME\tACTIVE\tVERSIONS\n")
+	for _, s := range secrets {
+		vers := make([]string, 0, len(s.Versions))
+		for _, v := range s.Versions {
+			vers = append(vers, v.String())
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\n", s.Name, s.ActiveVersion, strings.Join(vers, ","))
+	}
+	return tw.Flush()
+}
+
+var getArgs struct {
+	Version uint64
+}
+
+func runGet(ctx context.Context, args []string) error {
+	c, args, err := clientFromArgs(args)
+	if err != nil {
+		return err
+	}
+	if len(args) != 1 {
+		return flag.ErrHelp
+	}
+
+	name := args[0]
+
+	var val *api.SecretValue
+	if getArgs.Version == 0 {
+		val, err = c.Get(ctx, name)
+	} else {
+		val, err = c.GetVersion(ctx, name, api.SecretVersion(getArgs.Version))
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get secret: %v", err)
+	}
+
+	// Print with a newline if a human's going to look at it,
+	// otherwise output just the secret bytes.
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		fmt.Println(string(val.Value))
+	} else {
+		os.Stdout.Write(val.Value)
+	}
+	return nil
+}
+
+var putArgs struct {
+	File string
+}
+
+func runPut(ctx context.Context, args []string) error {
+	c, args, err := clientFromArgs(args)
+	if err != nil {
+		return err
+	}
+	if len(args) != 1 {
+		return flag.ErrHelp
+	}
+
+	name := args[0]
+
+	var value []byte
+	if putArgs.File != "" {
+		value, err = os.ReadFile(putArgs.File)
+		if err != nil {
+			return err
+		}
+		value = bytes.TrimSpace(value)
+	} else {
+		io.WriteString(os.Stdout, "Enter secret: ")
+		os.Stdout.Sync()
+		value, err = term.ReadPassword(int(os.Stdin.Fd()))
+		io.WriteString(os.Stdout, "\n")
+		if err != nil {
+			return err
+		}
+		if len(value) == 0 {
+			return errors.New("no secret provided, aborting")
+		}
+		io.WriteString(os.Stdout, "Confirm secret: ")
+		os.Stdout.Sync()
+		s2, err := term.ReadPassword(int(os.Stdin.Fd()))
+		io.WriteString(os.Stdout, "\n")
+		if err != nil {
+			return err
+		}
+		if !bytes.Equal(value, s2) {
+			return errors.New("secrets do not match, aborting")
+		}
+	}
+
+	ver, err := c.Put(ctx, name, value)
+	if err != nil {
+		return fmt.Errorf("failed to write secret: %w", err)
+	}
+	fmt.Printf("Secret saved as %q, version %d\n", name, ver)
+	return nil
+}
+
+func runSetActive(ctx context.Context, args []string) error {
+	c, args, err := clientFromArgs(args)
+	if err != nil {
+		return err
+	}
+	if len(args) != 2 {
+		return flag.ErrHelp
+	}
+
+	name := args[0]
+	version, err := strconv.ParseUint(args[1], 10, 32)
+	if err != nil {
+		return fmt.Errorf("invalid version %q: %w", version, err)
+	}
+
+	if err := c.SetActiveVersion(ctx, name, api.SecretVersion(version)); err != nil {
+		return fmt.Errorf("failed to set active version: %w", err)
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/tailscale/hujson v0.0.0-20221223112325-20486734a56a
 	github.com/tink-crypto/tink-go/v2 v2.0.0
 	golang.org/x/exp v0.0.0-20230725093048-515e97ebf090
+	golang.org/x/term v0.10.0
 	tailscale.com v1.1.1-0.20230728214252-0554deb48c75
 )
 
@@ -77,7 +78,6 @@ require (
 	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/sync v0.2.0 // indirect
 	golang.org/x/sys v0.10.0 // indirect
-	golang.org/x/term v0.10.0 // indirect
 	golang.org/x/text v0.11.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.9.1 // indirect

--- a/server/server.go
+++ b/server/server.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 
 	"github.com/tailscale/setec/db"
@@ -127,6 +128,7 @@ func serveJSON[REQ any, RESP any](s *Server, w http.ResponseWriter, r *http.Requ
 
 	var req REQ
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		log.Print(err)
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
 	}

--- a/types/api/api.go
+++ b/types/api/api.go
@@ -5,6 +5,8 @@
 // server.
 package api
 
+import "strconv"
+
 // SecretVersion is the version of a secret.
 //
 // Secrets can have multiple values over time, for example when API
@@ -13,6 +15,10 @@ package api
 // value return a higher version than before, so the SecretVersion can
 // be interpreted as a chronological order of the secret's values.
 type SecretVersion uint32
+
+func (v SecretVersion) String() string {
+	return strconv.FormatUint(uint64(v), 10)
+}
 
 // SecretVersionDefault is a version that means the client wants the
 // server to pick an appropriate secret version. Currently, the server


### PR DESCRIPTION
Updates tailscale/corp#13375

---

Dev server is running at https://setec-dev.corp.ts.net , you should be able to access it. I configured ACLs to permit kylie@, fromberger@, maisem@ to do anything. Suggested commands:

```
# List secrets you're allowed to see
./setec list https://setec-dev.corp.ts.net
# Get the currently active ACLs
./setec get https://setec-dev.corp.ts.net _internal/acl
# Get an inactive version of secret "test"
./setec get --version=2 https://setec-dev.corp.ts.net test
# Create a new secret with interactive terminal prompting
./setec put https://setec-dev.corp.ts.net some-new-secret
```

The UX of having to provide a full HTTPS URL isn't great, but I was ratholing on how to infer the correct query domain and such so as to not end up needing an HTTPS redirect (which eats the body and thus causes other grief), and decided to defer until later. So, for now, icky UX it is.