### PR TITLE
server: switch API to POST, block browser access

### DIFF
--- a/client/setec/client.go
+++ b/client/setec/client.go
@@ -84,11 +84,13 @@ func do[RESP, REQ any](ctx context.Context, c *Client, path string, req REQ) (RE
 
 	url := fmt.Sprintf("%s/%s", strings.TrimSuffix(c.Server, "/"), strings.TrimPrefix(path, "/"))
 
-	r, err := http.NewRequestWithContext(ctx, "GET", url, bytes.NewReader(bs))
+	r, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(bs))
 	if err != nil {
 		return resp, fmt.Errorf("constructing HTTP request: %w", err)
 	}
 	r.Header.Set("Content-Type", "application/json")
+	// See the comment in server/server.go for what this does.
+	r.Header.Set("Sec-X-Tailscale-No-Browsers", "setec")
 
 	do := c.DoHTTP
 	if do == nil {


### PR DESCRIPTION
Updates tailscale/corp#13375

---

The `Sec-...` header is a temporary thing, just kicking the can down the road a bit before I have to re-learn the state of the art for defense against browser dark arts.