### PR TITLE
server: pull group membership from tailscale whois

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/tink-crypto/tink-go/v2 v2.0.0
 	golang.org/x/exp v0.0.0-20230725093048-515e97ebf090
 	golang.org/x/term v0.10.0
-	tailscale.com v1.1.1-0.20230728214252-0554deb48c75
+	tailscale.com v1.1.1-0.20230729175333-68f8e5678ef6
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -255,5 +255,5 @@ inet.af/wf v0.0.0-20221017222439-36129f591884 h1:zg9snq3Cpy50lWuVqDYM7AIRVTtU50y
 nhooyr.io/websocket v1.8.7 h1:usjR2uOr/zjjkVMy0lW+PPohFok7PCow5sDjLgX4P4g=
 nhooyr.io/websocket v1.8.7/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=
 software.sslmate.com/src/go-pkcs12 v0.2.0 h1:nlFkj7bTysH6VkC4fGphtjXRbezREPgrHuJG20hBGPE=
-tailscale.com v1.1.1-0.20230728214252-0554deb48c75 h1:dsE1egT9FD5LdDIkjjuRNDVJz6rpabrWu0+Qsd1zgXA=
-tailscale.com v1.1.1-0.20230728214252-0554deb48c75/go.mod h1:pWMxmTeHzTK4CZEfGhou1J5W7NsuGYwKA5y69X7hGJY=
+tailscale.com v1.1.1-0.20230729175333-68f8e5678ef6 h1:IwiS4VMMSCffltHo5mIqTZEygORS97btrwK5tp/TQDY=
+tailscale.com v1.1.1-0.20230729175333-68f8e5678ef6/go.mod h1:pWMxmTeHzTK4CZEfGhou1J5W7NsuGYwKA5y69X7hGJY=

--- a/server/server.go
+++ b/server/server.go
@@ -102,10 +102,10 @@ func (s *Server) getIdentity(r *http.Request) ([]string, error) {
 		return nil, fmt.Errorf("calling WhoIs: %w", err)
 	}
 
-	if who.UserProfile != nil && who.UserProfile.LoginName != "" {
-		return []string{who.UserProfile.LoginName}, nil
-	} else if who.Node != nil && len(who.Node.Tags) > 0 {
-		return who.Node.Tags, nil
+	if node := who.Node; node != nil && len(node.Tags) > 0 {
+		return node.Tags, nil
+	} else if user := who.UserProfile; user != nil && user.LoginName != "" {
+		return append([]string{user.LoginName}, user.Groups...), nil
 	}
 	return nil, errors.New("failed to find caller identity")
 }


### PR DESCRIPTION
Updates tailscale/corp#13375

---

The live ACL on setec-dev now grants list, put, set-active to `group:prod`. get and delete are ACLd to just us. I verified that everything still works with that ACL, with group information coming from tailscale.