### PR TITLE
db: re-use the version for re-Put of the latest value

### DIFF
--- a/db/kv.go
+++ b/db/kv.go
@@ -304,6 +304,12 @@ func (kv *kv) put(name string, value []byte) (api.SecretVersion, error) {
 		return 1, nil
 	}
 
+	// If the new value is the same as the current latest version, don't store a
+	// new copy.
+	if bytes.Equal(s.Versions[s.LatestVersion], value) {
+		return s.LatestVersion, nil
+	}
+
 	s.LatestVersion++
 	s.Versions[s.LatestVersion] = value
 	if err := kv.save(); err != nil {


### PR DESCRIPTION
When putting a (new) secret, only assign a new version if the new value is
different from the previous most-recent value.  This check does not extend to
all previous values, only the latest. Add tests for same.
