### PR TITLE
db: do not alias the input buffer after Put

### DIFF
--- a/db/db_test.go
+++ b/db/db_test.go
@@ -335,6 +335,15 @@ func TestPut(t *testing.T) {
 		}
 		return id
 	}
+	mustGetVersion := func(id api.SecretVersion, want string) {
+		t.Helper()
+		got, err := d.DB.GetVersion(testName, id, from)
+		if err != nil {
+			t.Fatalf("Get %q version %v: unexpected error: %v", testName, id, err)
+		} else if !bytes.Equal(got.Value, []byte(want)) {
+			t.Fatalf("Get %q version %v: got %q, want %q", testName, id, got.Value, want)
+		}
+	}
 
 	testValue1 := []byte("test value 1")
 	testValue2 := []byte("test value 2")
@@ -345,7 +354,7 @@ func TestPut(t *testing.T) {
 	// Re-putting the same value should report the same version.
 	id2 := mustPut(testValue1)
 	if id1 != id2 {
-		t.Errorf("Put %q again: got %v, want %v", testName, id2, id1)
+		t.Fatalf("Put %q again: got %v, want %v", testName, id2, id1)
 	}
 
 	// Putting a different value must give a new version.
@@ -359,6 +368,15 @@ func TestPut(t *testing.T) {
 	if id4 == id3 {
 		t.Fatalf("Put %q fresh value: got %v, want a new version", testName, id4)
 	}
+
+	// The values stored in the database should not alias the input.  The caller
+	// may reuse the buffer after storing it.
+
+	testValue1[len(testValue1)-1] = 'Q' // test value Q
+	testValue2[len(testValue2)-1] = '?' // test value ?
+
+	mustGetVersion(id1, "test value 1")
+	mustGetVersion(id3, "test value 2")
 }
 
 // TODO(corp/13375): tests that verify ACL enforcement. Not

--- a/db/kv.go
+++ b/db/kv.go
@@ -294,7 +294,7 @@ func (kv *kv) put(name string, value []byte) (api.SecretVersion, error) {
 			LatestVersion: 1,
 			ActiveVersion: 1,
 			Versions: map[api.SecretVersion][]byte{
-				1: value,
+				1: bytes.Clone(value),
 			},
 		}
 		if err := kv.save(); err != nil {
@@ -311,7 +311,7 @@ func (kv *kv) put(name string, value []byte) (api.SecretVersion, error) {
 	}
 
 	s.LatestVersion++
-	s.Versions[s.LatestVersion] = value
+	s.Versions[s.LatestVersion] = bytes.Clone(value)
 	if err := kv.save(); err != nil {
 		delete(s.Versions, s.LatestVersion)
 		s.LatestVersion--


### PR DESCRIPTION
The caller may re-use the slice after storing it in the database, for example
if it came from a buffer they're using to pull in values from somewhere else.
Don't let changes to the caller's buffer reflect in the KV map.

We might also want to do this on the way back out, but this change doesn't do
that (yet).  Alternatively, we might make the input and return values be
strings, which still gives a copy but makes it easier to test.
