### PR TITLE
db: store secrets in the map as string instead of []byte

### DIFF
--- a/db/db_test.go
+++ b/db/db_test.go
@@ -335,6 +335,15 @@ func TestPut(t *testing.T) {
 		}
 		return id
 	}
+	mustGetVersion := func(id api.SecretVersion, want string) {
+		t.Helper()
+		got, err := d.DB.GetVersion(testName, id, from)
+		if err != nil {
+			t.Fatalf("Get %q version %v: unexpected error: %v", testName, id, err)
+		} else if !bytes.Equal(got.Value, []byte(want)) {
+			t.Fatalf("Get %q version %v: got %q, want %q", testName, id, got.Value, want)
+		}
+	}
 
 	testValue1 := []byte("test value 1")
 	testValue2 := []byte("test value 2")
@@ -345,7 +354,7 @@ func TestPut(t *testing.T) {
 	// Re-putting the same value should report the same version.
 	id2 := mustPut(testValue1)
 	if id1 != id2 {
-		t.Errorf("Put %q again: got %v, want %v", testName, id2, id1)
+		t.Fatalf("Put %q again: got %v, want %v", testName, id2, id1)
 	}
 
 	// Putting a different value must give a new version.
@@ -359,6 +368,15 @@ func TestPut(t *testing.T) {
 	if id4 == id3 {
 		t.Fatalf("Put %q fresh value: got %v, want a new version", testName, id4)
 	}
+
+	// The values stored in the database should not alias the input.  The caller
+	// may reuse the buffer after storing it.
+
+	testValue1[len(testValue1)-1] = 'Q' // test value Q
+	testValue2[len(testValue2)-1] = '?' // test value ?
+
+	mustGetVersion(id1, "test value 1")
+	mustGetVersion(id3, "test value 2")
 }
 
 // TODO(corp/13375): tests that verify ACL enforcement. Not

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -335,7 +335,7 @@ func TestPut(t *testing.T) {
 		}
 		return id
 	}
-	mustGetVersion := func(id api.SecretVersion, want string) {
+	mustGetVersion := func(id api.SecretVersion, want string) *api.SecretValue {
 		t.Helper()
 		got, err := d.DB.GetVersion(testName, id, from)
 		if err != nil {
@@ -343,6 +343,7 @@ func TestPut(t *testing.T) {
 		} else if !bytes.Equal(got.Value, []byte(want)) {
 			t.Fatalf("Get %q version %v: got %q, want %q", testName, id, got.Value, want)
 		}
+		return got
 	}
 
 	testValue1 := []byte("test value 1")
@@ -374,6 +375,14 @@ func TestPut(t *testing.T) {
 
 	testValue1[len(testValue1)-1] = 'Q' // test value Q
 	testValue2[len(testValue2)-1] = '?' // test value ?
+
+	v1 := mustGetVersion(id1, "test value 1")
+	v2 := mustGetVersion(id3, "test value 2")
+
+	// Mutating the values returned by the database should not affect what the
+	// database has stored.
+	v1.Value[0] = 'Q'
+	v2.Value[0] = '?'
 
 	mustGetVersion(id1, "test value 1")
 	mustGetVersion(id3, "test value 2")

--- a/db/kv.go
+++ b/db/kv.go
@@ -99,6 +99,9 @@ type secret struct {
 	LatestVersion api.SecretVersion
 }
 
+// byteString is an alias for a string, but encodes to JSON as the conventional
+// base64 encoding used for []byte. We do this since we expect secrets to have
+// random binary content, and are storing them as strings for immutability.
 type byteString string
 
 func (b *byteString) UnmarshalText(text []byte) error {

--- a/db/kv.go
+++ b/db/kv.go
@@ -5,6 +5,7 @@ package db
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -89,13 +90,28 @@ type secret struct {
 	//
 	// We rely on api.SecretVersion being a type encoding/json will translate to
 	// a JSON string (currently an integer).
-	Versions map[api.SecretVersion][]byte
+	Versions map[api.SecretVersion]byteString
 	// ActiveVersion is the secret version that gets returned to
 	// clients who don't ask for a specific version of the secret.
 	ActiveVersion api.SecretVersion
 	// LatestVersion is the latest version that has already been used
 	// by a previous Put.
 	LatestVersion api.SecretVersion
+}
+
+type byteString string
+
+func (b *byteString) UnmarshalText(text []byte) error {
+	dec, err := base64.StdEncoding.DecodeString(string(text))
+	if err != nil {
+		return err
+	}
+	*b = byteString(dec)
+	return nil
+}
+
+func (b byteString) MarshalText() ([]byte, error) {
+	return []byte(base64.StdEncoding.EncodeToString([]byte(b))), nil
 }
 
 // persist is the portion of DB that is persisted to disk, before
@@ -257,12 +273,12 @@ func (kv *kv) get(name string) (*api.SecretValue, error) {
 	if secret == nil {
 		return nil, ErrNotFound
 	}
-	bs := secret.Versions[secret.ActiveVersion]
-	if bs == nil {
+	bs, ok := secret.Versions[secret.ActiveVersion]
+	if !ok {
 		return nil, errors.New("[unexpected] active secret version missing from DB")
 	}
 	return &api.SecretValue{
-		Value:   bs,
+		Value:   []byte(bs),
 		Version: secret.ActiveVersion,
 	}, nil
 }
@@ -273,12 +289,12 @@ func (kv *kv) getVersion(name string, version api.SecretVersion) (*api.SecretVal
 	if secret == nil {
 		return nil, ErrNotFound
 	}
-	bs := secret.Versions[version]
-	if bs == nil {
+	bs, ok := secret.Versions[version]
+	if !ok {
 		return nil, ErrNotFound
 	}
 	return &api.SecretValue{
-		Value:   bs,
+		Value:   []byte(bs),
 		Version: version,
 	}, nil
 }
@@ -293,8 +309,8 @@ func (kv *kv) put(name string, value []byte) (api.SecretVersion, error) {
 		kv.secrets[name] = &secret{
 			LatestVersion: 1,
 			ActiveVersion: 1,
-			Versions: map[api.SecretVersion][]byte{
-				1: value,
+			Versions: map[api.SecretVersion]byteString{
+				1: byteString(value),
 			},
 		}
 		if err := kv.save(); err != nil {
@@ -306,12 +322,13 @@ func (kv *kv) put(name string, value []byte) (api.SecretVersion, error) {
 
 	// If the new value is the same as the current latest version, don't store a
 	// new copy.
-	if bytes.Equal(s.Versions[s.LatestVersion], value) {
+	bsValue := byteString(value)
+	if s.Versions[s.LatestVersion] == bsValue {
 		return s.LatestVersion, nil
 	}
 
 	s.LatestVersion++
-	s.Versions[s.LatestVersion] = value
+	s.Versions[s.LatestVersion] = bsValue
 	if err := kv.save(); err != nil {
 		delete(s.Versions, s.LatestVersion)
 		s.LatestVersion--
@@ -330,8 +347,7 @@ func (kv *kv) setActive(name string, version api.SecretVersion) error {
 	if secret == nil {
 		return ErrNotFound
 	}
-	bs := secret.Versions[version]
-	if bs == nil {
+	if _, ok := secret.Versions[version]; !ok {
 		return ErrNotFound
 	}
 	if secret.ActiveVersion == version {


### PR DESCRIPTION
An alternative to #19, that avoids aliasing both on input and output.
Convert the map value to a string type that marshals like []byte.
