### PR TITLE
server: simplify extraction of identity from whois

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -102,12 +102,11 @@ func (s *Server) getIdentity(r *http.Request) ([]string, error) {
 		return nil, fmt.Errorf("calling WhoIs: %w", err)
 	}
 
-	if node := who.Node; node != nil && len(node.Tags) > 0 {
-		return node.Tags, nil
-	} else if user := who.UserProfile; user != nil && user.LoginName != "" {
-		return append([]string{user.LoginName}, user.Groups...), nil
+	if who.Node.IsTagged() {
+		return who.Node.Tags, nil
+	} else {
+		return append([]string{who.UserProfile.LoginName}, who.UserProfile.Groups...), nil
 	}
-	return nil, errors.New("failed to find caller identity")
 }
 
 // serveJSON calls fn to handle a JSON API request. fn is invoked with


### PR DESCRIPTION
The localapi guarantees non-nil elements in the whois response, and has a helper to distinguish tagged vs. untagged nodes.

Updates tailscale/corp#13375