### PR TITLE
server, acl: use peer capabilities provided by tailscale

### DIFF
--- a/acl/acl.go
+++ b/acl/acl.go
@@ -4,43 +4,13 @@
 // Package acl implements ACL evaluation for access to a secrets
 // database.
 //
-// ACL policy files are a HuJSON object that looks like:
-//
-//	{
-//	  "rules": [
-//	    {
-//	      "principal": ["tag:control", "tag:control-us"],
-//	      "action": ["get"],
-//	      "secret": ["prod/control/rudderstack-api-key", "prod/control/stripe-api-key"],
-//	    },
-//	    {
-//	      "principal": ["group:log-sources", "kylie@tailscale.com"],
-//	      "action": ["get"],
-//	      "secret": ["prod/elastic-agent-authkey"],
-//	    },
-//	    {
-//	      "principal": ["group:admins"],
-//	      "action": ["get", "list", "put", "set-active", "delete"],
-//	      "secret": ["*"],
-//	    },
-//	    {
-//	      "principal": ["dave@tailscale.com"],
-//	      "action": ["get", "list", "put", "set-active", "delete"],
-//	      "secret": ["dev/*", "prod/*/some-secret"],
-//	    },
-//	  ],
-//	}
+// ACL policies are provided by tailscale peer capabilities.
 package acl
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
-
-	"github.com/tailscale/hujson"
-	"tailscale.com/util/multierr"
 )
 
 // Action is an action on secrets that is subject to access control.
@@ -54,141 +24,61 @@ const (
 	ActionDelete    = Action("delete")
 )
 
-// Policy is an ACL policy that controls access to secrets.
-type Policy struct {
-	rules []compiledRule
-}
+// Rules is a set of ACLs for access to a secret.
+type Rules []Rule
 
-// Compile returns a Policy that enforces the ACLs in bs.
-func Compile(bs []byte) (*Policy, error) {
-	bs, err := hujson.Standardize(bs)
-	if err != nil {
-		return nil, fmt.Errorf("converting ACL policy to JSON: %w", err)
-	}
-
-	type rule struct {
-		From   []string `json:"principal"`
-		Secret []string `json:"secret"`
-		Action []Action `json:"action"`
-	}
-	var pol struct {
-		Rules []rule `json:"rules"`
-	}
-	dec := json.NewDecoder(bytes.NewBuffer(bs))
-	dec.DisallowUnknownFields()
-	if err := dec.Decode(&pol); err != nil {
-		return nil, fmt.Errorf("parsing ACL policy JSON: %w", err)
-	}
-
-	ret := &Policy{}
-	var errs []error
-
-	for i, r := range pol.Rules {
-		ruleNum := i + 1
-
-		from, err := expandFrom(ruleNum, r.From)
-		if err != nil {
-			errs = append(errs, err)
-		}
-		secret, err := expandSecret(ruleNum, r.Secret)
-		if err != nil {
-			errs = append(errs, err)
-		}
-		action, err := expandAction(ruleNum, r.Action)
-		if err != nil {
-			errs = append(errs, err)
-		}
-		ret.rules = append(ret.rules, compiledRule{from, secret, action})
-	}
-
-	if len(errs) > 0 {
-		return nil, multierr.New(errs...)
-	}
-	return ret, nil
-}
-
-// Allow reports whether anyone in 'from' can perform 'action' on 'secret'.
-func (p *Policy) Allow(from []string, secret string, action Action) bool {
-	for _, r := range p.rules {
-		if r.allow(from, secret, action) {
+// Allow reports whether the ACLs allow action on secret.
+func (rr Rules) Allow(action Action, secret string) bool {
+	for _, r := range rr {
+		if r.Allow(action, secret) {
 			return true
 		}
 	}
 	return false
 }
 
-type compiledRule struct {
-	from   map[string]bool
-	secret *regexp.Regexp
-	action map[Action]bool
+// Rule is an access control rule that permits some actions on some
+// secrets. Secrets can contain '*' wildcards, which match zero or
+// more characters.
+type Rule struct {
+	Action []Action `json:"action"`
+	Secret []string `json:"secret"`
 }
 
-func (r *compiledRule) allow(from []string, secret string, action Action) bool {
-	if !r.action[action] {
+// Allow reports whether the rule allows action on secret.
+func (r *Rule) Allow(action Action, secret string) bool {
+	actionMatches := func(acts []Action) bool {
+		for _, a := range acts {
+			if a == action {
+				return true
+			}
+		}
 		return false
 	}
-	if !r.secret.MatchString(secret) {
+	secretMatches := func(secs []string) bool {
+		for _, s := range secs {
+			if !strings.Contains(s, "*") && s == secret {
+				return true
+			}
+			// We want the user to use glob-ish syntax, where '*' is the
+			// equivalent of regexp's '.*'. We also don't want any other
+			// character of the input misinterpreted as a regexp control
+			// character.
+			//
+			// To achieve this, we:
+			//  - split each input string on '*'
+			//  - regexp-quote the resulting parts
+			//  - reassemble the quoted parts around '.*' separators
+			parts := strings.Split(s, "*")
+			for i := range parts {
+				parts[i] = regexp.QuoteMeta(parts[i])
+			}
+			re := regexp.MustCompile(fmt.Sprintf("^%s$", strings.Join(parts, ".*")))
+			if re.MatchString(secret) {
+				return true
+			}
+		}
 		return false
 	}
-	for _, f := range from {
-		if r.from[f] {
-			return true
-		}
-	}
-	return false
-}
-
-// expandFrom converts from into a map for fast lookups.
-func expandFrom(ruleNum int, from []string) (map[string]bool, error) {
-	ret := map[string]bool{}
-	for _, f := range from {
-		ret[f] = true
-	}
-	return ret, nil
-}
-
-// expandSecret converts secret into a regular expression for fast
-// matching.
-func expandSecret(ruleNum int, secret []string) (*regexp.Regexp, error) {
-	var ret []string
-	// We want the user to use glob-ish syntax, where '*' is the
-	// equivalent of regexp's '.*'. We also don't want any other
-	// character of the input misinterpreted as a regexp control
-	// character.
-	//
-	// To achieve this, we:
-	//  - split each input string on '*'
-	//  - regexp-quote the resulting parts
-	//  - reassemble the quoted parts around '.*' separators
-	//  - join all the converted inputs together with '|'
-	//
-	// The result is a single regex that expresses "any of the forms
-	// in secret", with our desired glob-ish wildcard.
-	for _, s := range secret {
-		parts := strings.Split(s, "*")
-		for i := range parts {
-			parts[i] = regexp.QuoteMeta(parts[i])
-		}
-		ret = append(ret, strings.Join(parts, ".*"))
-	}
-	reStr := fmt.Sprintf("^(?:%s)$", strings.Join(ret, "|"))
-	return regexp.Compile(reStr)
-}
-
-// expandAction converts action into a map for fast lookups.
-func expandAction(ruleNum int, action []Action) (map[Action]bool, error) {
-	ret := map[Action]bool{}
-	var errs []error
-	for _, a := range action {
-		switch a {
-		case ActionGet, ActionList, ActionPut, ActionSetActive, ActionDelete:
-			ret[a] = true
-		default:
-			errs = append(errs, fmt.Errorf("rule %d has unknown action %q", ruleNum, a))
-		}
-	}
-	if len(errs) > 0 {
-		return nil, multierr.New(errs...)
-	}
-	return ret, nil
+	return actionMatches(r.Action) && secretMatches(r.Secret)
 }

--- a/db/kv.go
+++ b/db/kv.go
@@ -248,11 +248,6 @@ func (kv *kv) list() []string {
 	return ret
 }
 
-// has reports whether a secret called name is defined in kv.
-func (kv *kv) has(name string) bool {
-	return kv.secrets[name] != nil
-}
-
 // info returns metadata about a secret.
 func (kv *kv) info(name string) (*api.SecretInfo, error) {
 	secret := kv.secrets[name]

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/tink-crypto/tink-go/v2 v2.0.0
 	golang.org/x/exp v0.0.0-20230725093048-515e97ebf090
 	golang.org/x/term v0.10.0
-	tailscale.com v1.1.1-0.20230729175333-68f8e5678ef6
+	tailscale.com v1.1.1-0.20230802164427-ab7749aed7ba
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,7 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dblohm7/wingoes v0.0.0-20230426155039-111c8c3b57c8 h1:vtIE3GO4hKplR58aTRx3yLPqAbfWyoyYrE8PXUv0Prw=
+github.com/dblohm7/wingoes v0.0.0-20230801195049-ed8077baf0cd h1:zYVpYS5d3Uf04vVCJuzqpOCwQQIzJibtOx8ivt7zt2Q=
 github.com/frankban/quicktest v1.14.5 h1:dfYrrRyLtiqT9GyKXgdh+k4inNeTvmGbuSgZ3lx3GhA=
 github.com/fxamacker/cbor/v2 v2.4.0 h1:ri0ArlOR+5XunOP8CRUowT0pSJOwhW098ZCUyskZD88=
 github.com/fxamacker/cbor/v2 v2.4.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
@@ -56,6 +57,7 @@ github.com/gin-gonic/gin v1.6.3 h1:ahKqKTFpO5KTPHxWZjEdPScmYaGtLo8Y4DMHoEsnp14=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
 github.com/github/fakeca v0.1.0 h1:Km/MVOFvclqxPM9dZBC4+QE564nU4gz4iZ0D9pMw28I=
 github.com/github/fakeca v0.1.0/go.mod h1:+bormgoGMMuamOscx7N91aOuUST7wdaJ2rNjeohylyo=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
@@ -106,10 +108,14 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/josharian/native v1.0.1-0.20221213033349-c1e37c09b531/go.mod h1:7X/raswPFr05uY3HiLlYeyQntB6OO7E/d2Cu7qoaN2w=
 github.com/josharian/native v1.1.1-0.20230202152459-5c7d0dd6ab86 h1:elKwZS1OcdQ0WwEDBeqxKwb7WB62QX8bvZ/FJnVXIfk=
 github.com/josharian/native v1.1.1-0.20230202152459-5c7d0dd6ab86/go.mod h1:aFAMtuldEgx/4q7iSGazk22+IcgvtiC+HIimFO9XlS8=
+github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/jsimonetti/rtnetlink v1.3.2 h1:dcn0uWkfxycEEyNy0IGfx3GrhQ38LH7odjxAghimsVI=
 github.com/jsimonetti/rtnetlink v1.3.2/go.mod h1:BBu4jZCpTjP6Gk0/wfrO8qcqymnN3g0hoFqObRmUo6U=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
+github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.10.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.16.5 h1:IFV2oUNUzZaz+XyusxpLzpzS8Pt5rh0Z16For/djlyI=
 github.com/klauspost/compress v1.16.5/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
@@ -117,6 +123,7 @@ github.com/kortschak/wol v0.0.0-20200729010619-da482cc4850a h1:+RR6SqnTkDLWyICxS
 github.com/kortschak/wol v0.0.0-20200729010619-da482cc4850a/go.mod h1:YTtCCM3ryyfiu4F7t8HQ1mxvp1UBdWM2r6Xa+nGWvDk=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
@@ -138,8 +145,11 @@ github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc
 github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
+github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/peterbourgon/ff/v3 v3.3.0 h1:PaKe7GW8orVFh8Unb5jNHS+JZBwWUMa2se0HM6/BI24=
 github.com/peterbourgon/ff/v3 v3.3.0/go.mod h1:zjJVUhx+twciwfDl0zBcFzl4dW8axCRyXE/eKY9RztQ=
 github.com/pierrec/lz4/v4 v4.1.14/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
@@ -244,6 +254,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gvisor.dev/gvisor v0.0.0-20230504175454-7b0a1988a28f h1:8GE2MRjGiFmfpon8dekPI08jEuNMQzSffVHgdupcO4E=
 gvisor.dev/gvisor v0.0.0-20230504175454-7b0a1988a28f/go.mod h1:pzr6sy8gDLfVmDAg8OYrlKvGEHw5C3PGTiBXBTCx76Q=
@@ -257,3 +268,5 @@ nhooyr.io/websocket v1.8.7/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0
 software.sslmate.com/src/go-pkcs12 v0.2.0 h1:nlFkj7bTysH6VkC4fGphtjXRbezREPgrHuJG20hBGPE=
 tailscale.com v1.1.1-0.20230729175333-68f8e5678ef6 h1:IwiS4VMMSCffltHo5mIqTZEygORS97btrwK5tp/TQDY=
 tailscale.com v1.1.1-0.20230729175333-68f8e5678ef6/go.mod h1:pWMxmTeHzTK4CZEfGhou1J5W7NsuGYwKA5y69X7hGJY=
+tailscale.com v1.1.1-0.20230802164427-ab7749aed7ba h1:En/5k0Ap++Bu+gnIQyKIElmauyPS4GUuMHN23Tmtqkg=
+tailscale.com v1.1.1-0.20230802164427-ab7749aed7ba/go.mod h1:t4bfBY5TSAZA5RQhvuFJHdtv2s65NsmYfJzCWk9tDNY=


### PR DESCRIPTION
Removes all internal ACL file support, but keeps the _internal namespace reserved for future use.

Updates tailscale/corp#13375