### PR TITLE
audit: start of audit log package

### DIFF
--- a/audit/audit.go
+++ b/audit/audit.go
@@ -1,0 +1,121 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Package audit provides an audit log writer for access to secrets.
+package audit
+
+import (
+	"encoding/json"
+	"io"
+	"math/rand"
+	"net/netip"
+	"os"
+	"time"
+
+	"github.com/tailscale/setec/acl"
+	"github.com/tailscale/setec/types/api"
+)
+
+// Principal is the identity of a client taking action on the secrets
+// service.
+type Principal struct {
+	// Hostname is the principal's Tailscale FQDN.
+	Hostname string `json:"hostname"`
+	// IP is one of the principal's Tailscale IPs that correspond to
+	// Hostname. The specific IP here depends on the builder of an
+	// instance of Principal, but is usually the IP from which a
+	// request was received.
+	IP netip.Addr `json:"ip"`
+	// User is the human identity of the principal, or the empty
+	// string if the principal is a tagged device.
+	User string `json:"user,omitempty"`
+	// Tags is the tags of the principal, or nil if the principal is
+	// not a tagged device.
+	Tags []string `json:"tags,omitempty"`
+}
+
+// Entry is an audit log entry.
+type Entry struct {
+	// ID is the entry's ID.
+	ID uint64 `json:"id"`
+	// Time is the entry's timestamp.
+	Time time.Time `json:"time"`
+	// Principal is the client who is doing something.
+	Principal Principal `json:"principal"`
+	// Action is the action being performed on a secret.
+	Action acl.Action `json:"action"`
+	// Secret is the name of the secret being acted upon.
+	Secret string `json:"secret"`
+	// SecretVersion is the version of the secret being acted upon, if
+	// applicable, or api.SecretVersionDefault if a version doesn't
+	// make sense for the action (e.g. listing a secret).
+	SecretVersion api.SecretVersion `json:"secretVersion,omitempty"`
+}
+
+// Writer is an audit log writer.
+type Writer struct {
+	w   io.Writer
+	enc *json.Encoder
+}
+
+// New returns a Writer that outputs audit log entries to w as JSON
+// objects. If w also implements io.Closer, Writer.Close closes w. If
+// w also implements a Sync method with the same signature as os.File,
+// Writer.Sync calls w.Sync.
+func New(w io.Writer) *Writer {
+	return &Writer{
+		w:   w,
+		enc: json.NewEncoder(w),
+	}
+}
+
+// NewFile returns a Writer that outputs audit log entries to a file
+// at path, creating it if necessary.
+func NewFile(path string) (*Writer, error) {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
+	if err != nil {
+		return nil, err
+	}
+	return New(f), nil
+}
+
+// Sync commits the current contents of the file to stable storage if
+// the Writer was created with a sink that itself implements Sync, or
+// else does nothing successfully.
+func (l *Writer) Sync() error {
+	if s, ok := l.w.(syncer); ok {
+		return s.Sync()
+	}
+	return nil
+}
+
+// Close closes the Writer if the writer was created with a sink that
+// implements io.Closer, or else does nothing successfully.
+func (l *Writer) Close() error {
+	if err := l.Sync(); err != nil {
+		return err
+	}
+	if c, ok := l.w.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
+}
+
+type syncer interface {
+	Sync() error
+}
+
+// WriteEntries writes entries to the audit log. Each entry's ID and
+// Time fields are set prior to writing, any existing value is
+// overwritten.
+func (l *Writer) WriteEntries(entries ...*Entry) error {
+	for _, e := range entries {
+		e.ID = rand.Uint64()
+		e.Time = time.Now().UTC()
+
+		if err := l.enc.Encode(e); err != nil {
+			return err
+		}
+	}
+	return l.Sync()
+}

--- a/audit/audit_test.go
+++ b/audit/audit_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package audit_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/netip"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tailscale/setec/audit"
+)
+
+func TestWriter(t *testing.T) {
+	var out bytes.Buffer
+
+	w := audit.New(&out)
+
+	entries := []*audit.Entry{
+		{
+			Principal: audit.Principal{
+				Hostname: "foo",
+				IP:       netip.MustParseAddr("1.2.3.4"),
+				User:     "flynn",
+			},
+			Action:        "get",
+			Secret:        "mcp/core/tron",
+			SecretVersion: 4,
+		},
+		{
+			Principal: audit.Principal{
+				Hostname: "bar",
+				IP:       netip.MustParseAddr("2.3.4.5"),
+				User:     "dillinger",
+			},
+			Action:        "delete",
+			Secret:        "mcp/core/tron",
+			SecretVersion: 0,
+		},
+	}
+
+	if err := w.WriteEntries(entries...); err != nil {
+		t.Fatalf("writing audit log entries: %v", err)
+	}
+	// Verify that WriteEntries set ID and Time
+	for i, e := range entries {
+		if e.ID == 0 {
+			t.Fatalf("ID was not set on entry %d", i+1)
+		}
+		if e.Time.IsZero() {
+			t.Fatalf("Time was not set on entry %d", i+1)
+		}
+	}
+
+	dec := json.NewDecoder(&out)
+	var got []*audit.Entry
+	for i := 0; i < len(entries); i++ {
+		var ent *audit.Entry
+		if err := dec.Decode(&ent); err != nil {
+			t.Fatalf("decoding audit entry %d: %v", i+1, err)
+		}
+		got = append(got, ent)
+	}
+
+	if diff := cmp.Diff(got, entries, cmp.Comparer(addrEqual)); diff != "" {
+		t.Fatalf("wrong audit log data on read-back (-got+want):\n%s", diff)
+	}
+}
+
+func addrEqual(x, y netip.Addr) bool { return x == y }


### PR DESCRIPTION
Two independently reviewable commits: one creates an audit log package with types + a writer, the other replaces the string "from" identity in the rest of the codebase with an audit.Principal struct.

This PR doesn't cause audit logs to happen yet, it's just teeing things up while we figure out the exact semantics that audit logs should have.