### PR TITLE
client: improve initialization and add tests for it

### DIFF
--- a/client/setec/store.go
+++ b/client/setec/store.go
@@ -346,9 +346,6 @@ func (s *Store) initializeActive(ctx context.Context) error {
 		}
 
 		// Otherwise, wait a bit and try again, with gentle backoff.
-		//
-		// TODO(creachadair): Maybe be more discriminating about which errors we
-		// will retry for. Also maybe log when we retry.
 		sleepFor(ctx, retryWait)
 		if retryWait < 4*time.Second {
 			retryWait += retryWait // caps at 4096ms


### PR DESCRIPTION
Instead of polling all the known secrets during initialization, only query for
those we have not yet got any value for. Add logging about what is still
missing.  Increase the maximum retry interval from 1s to 4s.
