### PR TITLE
setectest: add a package to simplify testing

### DIFF
--- a/db/db_test.go
+++ b/db/db_test.go
@@ -6,23 +6,19 @@ package db_test
 import (
 	"bytes"
 	"io"
-	"net/netip"
 	"os"
-	"path/filepath"
 	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/tailscale/setec/acl"
 	"github.com/tailscale/setec/audit"
 	"github.com/tailscale/setec/db"
+	"github.com/tailscale/setec/setectest"
 	"github.com/tailscale/setec/types/api"
-	"github.com/tink-crypto/tink-go/v2/testutil"
-	"github.com/tink-crypto/tink-go/v2/tink"
 )
 
 func TestCreate(t *testing.T) {
-	tdb := newTestDB(t)
+	tdb := setectest.NewDB(t, nil)
 
 	// Verify that the DB was created, and save its bytes to verify
 	// that the next open just reads, without mutation.
@@ -31,7 +27,7 @@ func TestCreate(t *testing.T) {
 		t.Fatalf("reading back database: %v", err)
 	}
 
-	if _, err = db.Open(tdb.Path, tdb.KEK, audit.New(io.Discard)); err != nil {
+	if _, err = db.Open(tdb.Path, tdb.Key, audit.New(io.Discard)); err != nil {
 		t.Fatalf("opening test DB: %v", err)
 	}
 
@@ -45,44 +41,9 @@ func TestCreate(t *testing.T) {
 	}
 }
 
-type testDB struct {
-	Path string
-	DB   *db.DB
-	KEK  tink.AEAD
-}
-
-func newTestDB(t *testing.T) *testDB {
-	t.Helper()
-	path := filepath.Join(t.TempDir(), "test.db")
-	aead := &testutil.DummyAEAD{
-		Name: "TestKV-" + t.Name(),
-	}
-	database, err := db.Open(path, aead, audit.New(io.Discard))
-	if err != nil {
-		t.Fatalf("creating test DB: %v", err)
-	}
-	return &testDB{path, database, aead}
-}
-
-func superuser() db.Caller {
-	return db.Caller{
-		Principal: audit.Principal{
-			User:     "flynn",
-			IP:       netip.MustParseAddr("1.2.3.4"),
-			Hostname: "mcp",
-		},
-		Permissions: acl.Rules{
-			acl.Rule{
-				Action: []acl.Action{acl.ActionGet, acl.ActionInfo, acl.ActionPut, acl.ActionSetActive, acl.ActionDelete},
-				Secret: []acl.Secret{"*"},
-			},
-		},
-	}
-}
-
 func TestList(t *testing.T) {
-	d := newTestDB(t)
-	id := superuser()
+	d := setectest.NewDB(t, nil)
+	id := d.Superuser
 
 	checkList := func(d *db.DB, want []*api.SecretInfo) {
 		t.Helper()
@@ -95,12 +56,10 @@ func TestList(t *testing.T) {
 		}
 	}
 
-	checkList(d.DB, []*api.SecretInfo(nil))
+	checkList(d.Actual, []*api.SecretInfo(nil))
 
-	if _, err := d.DB.Put(id, "test", []byte("foo")); err != nil {
-		t.Fatalf("putting secret: %v", err)
-	}
-	checkList(d.DB, []*api.SecretInfo{
+	d.MustPut(id, "test", "foo")
+	checkList(d.Actual, []*api.SecretInfo{
 		{
 			Name:          "test",
 			Versions:      []api.SecretVersion{1},
@@ -108,10 +67,8 @@ func TestList(t *testing.T) {
 		},
 	})
 
-	if _, err := d.DB.Put(id, "test", []byte("bar")); err != nil {
-		t.Fatalf("putting secret: %v", err)
-	}
-	checkList(d.DB, []*api.SecretInfo{
+	d.MustPut(id, "test", "bar")
+	checkList(d.Actual, []*api.SecretInfo{
 		{
 			Name:          "test",
 			Versions:      []api.SecretVersion{1, 2},
@@ -119,10 +76,8 @@ func TestList(t *testing.T) {
 		},
 	})
 
-	if _, err := d.DB.Put(id, "test2", []byte("quux")); err != nil {
-		t.Fatalf("putting secret: %v", err)
-	}
-	checkList(d.DB, []*api.SecretInfo{
+	d.MustPut(id, "test2", "quux")
+	checkList(d.Actual, []*api.SecretInfo{
 		{
 			Name:          "test",
 			Versions:      []api.SecretVersion{1, 2},
@@ -135,10 +90,8 @@ func TestList(t *testing.T) {
 		},
 	})
 
-	if err := d.DB.SetActiveVersion(id, "test", api.SecretVersion(2)); err != nil {
-		t.Fatalf("setting active version: %v", err)
-	}
-	checkList(d.DB, []*api.SecretInfo{
+	d.MustSetActiveVersion(id, "test", 2)
+	checkList(d.Actual, []*api.SecretInfo{
 		{
 			Name:          "test",
 			Versions:      []api.SecretVersion{1, 2},
@@ -151,7 +104,7 @@ func TestList(t *testing.T) {
 		},
 	})
 
-	d2, err := db.Open(d.Path, d.KEK, audit.New(io.Discard))
+	d2, err := db.Open(d.Path, d.Key, audit.New(io.Discard))
 	if err != nil {
 		t.Fatalf("reopening database: %v", err)
 	}
@@ -170,52 +123,38 @@ func TestList(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
-	d := newTestDB(t)
-	id := superuser()
+	d := setectest.NewDB(t, nil)
+	id := d.Superuser
 
 	seen := map[api.SecretVersion][]byte{}
 	for i := 0; i < 10; i++ {
-		s := []byte(strconv.Itoa(i))
-		ver, err := d.DB.Put(id, "test", s)
-		if err != nil {
-			t.Fatalf("putting secret %d: %v", i, err)
-		}
+		s := strconv.Itoa(i)
+		ver := d.MustPut(id, "test", s)
 		if seen[ver] != nil {
 			t.Fatalf("multiple puts returned version %d", i)
 		}
-		seen[ver] = s
+		seen[ver] = []byte(s)
 	}
 
-	sec, err := d.DB.Get(id, "test")
-	if err != nil {
-		t.Fatalf("getting secret: %v", err)
-	}
+	sec := d.MustGet(id, "test")
 	if want := []byte("0"); !bytes.Equal(sec.Value, want) {
 		t.Fatalf("active secret is %q, want %q", sec.Value, want)
 	}
 
 	for v, want := range seen {
-		sec, err = d.DB.GetVersion(id, "test", v)
-		if err != nil {
-			t.Fatalf("getting secret version %d: %v", v, err)
-		}
+		sec := d.MustGetVersion(id, "test", v)
 		if !bytes.Equal(sec.Value, want) {
 			t.Fatalf("secret version %d is %q, want %q", v, sec.Value, want)
 		}
 
-		if err := d.DB.SetActiveVersion(id, "test", v); err != nil {
-			t.Fatalf("setting %d as active: %v", v, err)
-		}
-		sec, err = d.DB.Get(id, "test")
-		if err != nil {
-			t.Fatalf("getting active secret: %v", err)
-		}
+		d.MustSetActiveVersion(id, "test", v)
+		sec = d.MustGet(id, "test")
 		if !bytes.Equal(sec.Value, want) {
 			t.Fatalf("active secret is %q, want %q", sec.Value, want)
 		}
 	}
 
-	d2, err := db.Open(d.Path, d.KEK, audit.New(io.Discard))
+	d2, err := db.Open(d.Path, d.Key, audit.New(io.Discard))
 	if err != nil {
 		t.Fatalf("reopening database: %v", err)
 	}
@@ -232,24 +171,14 @@ func TestGet(t *testing.T) {
 }
 
 func TestPut(t *testing.T) {
-	d := newTestDB(t)
-	id := superuser()
+	d := setectest.NewDB(t, nil)
+	id := d.Superuser
 
 	const testName = "test-secret-name"
-	mustPut := func(v []byte) api.SecretVersion {
-		t.Helper()
-		id, err := d.DB.Put(id, testName, v)
-		if err != nil {
-			t.Fatalf("Put %q: unexpected error: %v", testName, err)
-		}
-		return id
-	}
 	mustGetVersion := func(version api.SecretVersion, want string) *api.SecretValue {
 		t.Helper()
-		got, err := d.DB.GetVersion(id, testName, version)
-		if err != nil {
-			t.Fatalf("Get %q version %v: unexpected error: %v", testName, id, err)
-		} else if !bytes.Equal(got.Value, []byte(want)) {
+		got := d.MustGetVersion(id, testName, version)
+		if !bytes.Equal(got.Value, []byte(want)) {
 			t.Fatalf("Get %q version %v: got %q, want %q", testName, id, got.Value, want)
 		}
 		return got
@@ -259,22 +188,22 @@ func TestPut(t *testing.T) {
 	testValue2 := []byte("test value 2")
 
 	// Putting a new value should assign a fresh version.
-	ver1 := mustPut(testValue1)
+	ver1 := d.MustPut(id, testName, string(testValue1))
 
 	// Re-putting the same value should report the same version.
-	ver2 := mustPut(testValue1)
+	ver2 := d.MustPut(id, testName, string(testValue1))
 	if ver1 != ver2 {
 		t.Fatalf("Put %q again: got %v, want %v", testName, ver2, ver1)
 	}
 
 	// Putting a different value must give a new version.
-	ver3 := mustPut(testValue2)
+	ver3 := d.MustPut(id, testName, string(testValue2))
 	if ver3 == ver1 {
 		t.Fatalf("Put %q fresh value: got %v, want a new version", testName, ver3)
 	}
 
 	// Putting the original value gets us a new version again.
-	ver4 := mustPut(testValue1)
+	ver4 := d.MustPut(id, testName, string(testValue1))
 	if ver4 == ver3 {
 		t.Fatalf("Put %q fresh value: got %v, want a new version", testName, ver4)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -124,7 +124,8 @@ func (s *Server) setActive(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-const aclCap tailcfg.PeerCapability = "https://tailscale.com/cap/secrets"
+// ACLCap is the capability name used for setec ACL permissions.
+const ACLCap tailcfg.PeerCapability = "https://tailscale.com/cap/secrets"
 
 // getIdentity extracts identity and permissions from an HTTP request.
 func (s *Server) getIdentity(r *http.Request) (id db.Caller, err error) {
@@ -149,7 +150,7 @@ func (s *Server) getIdentity(r *http.Request) (id db.Caller, err error) {
 	id.Principal.IP = addrPort.Addr()
 	id.Principal.Hostname = who.Node.Name
 
-	id.Permissions, err = tailcfg.UnmarshalCapJSON[acl.Rule](who.CapMap, aclCap)
+	id.Permissions, err = tailcfg.UnmarshalCapJSON[acl.Rule](who.CapMap, ACLCap)
 	if err != nil {
 		return db.Caller{}, fmt.Errorf("unmarshaling peer capabilities: %w", err)
 	}

--- a/setectest/dbtest.go
+++ b/setectest/dbtest.go
@@ -1,0 +1,139 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package setectest
+
+import (
+	"io"
+	"net/netip"
+	"path/filepath"
+	"testing"
+
+	"github.com/tailscale/setec/acl"
+	"github.com/tailscale/setec/audit"
+	"github.com/tailscale/setec/db"
+	"github.com/tailscale/setec/types/api"
+	"github.com/tink-crypto/tink-go/v2/testutil"
+	"github.com/tink-crypto/tink-go/v2/tink"
+)
+
+// superuser returns a db.Caller that has full access to all operations on all
+// secrete. Each call constructs a fresh value so the caller can make changes
+// safely without aliasing the slices.
+func superuser() db.Caller {
+	return db.Caller{
+		Principal: audit.Principal{
+			User:     "flynn",
+			IP:       netip.MustParseAddr("1.2.3.4"),
+			Hostname: "mcp",
+		},
+		Permissions: acl.Rules{
+			acl.Rule{
+				Action: []acl.Action{
+					acl.ActionGet, acl.ActionInfo, acl.ActionPut, acl.ActionSetActive, acl.ActionDelete,
+				},
+				Secret: []acl.Secret{"*"},
+			},
+		},
+	}
+}
+
+// DB is a wrapper around a setec database to simplify creating database
+// instances for unit tests with the testing package.
+type DB struct {
+	t *testing.T
+
+	Path      string    // the path of the database file
+	Key       tink.AEAD // the key-encryption key (dummy)
+	Actual    *db.DB    // the underlying database
+	Superuser db.Caller // a pre-defined super-user for all secrets & operations
+}
+
+// DBOptions are options for constructing a test database.
+// A nil *Options is ready for use and provides defaults as described.
+type DBOptions struct {
+	// AuditLog is where audit logs are written; if nil, audit logs are
+	// discarded without error.
+	AuditLog *audit.Writer
+}
+
+func (o *DBOptions) auditWriter() *audit.Writer {
+	if o == nil || o.AuditLog == nil {
+		return audit.New(io.Discard)
+	}
+	return o.AuditLog
+}
+
+// NewDB constructs a new empty DB that persists for the duration of the test
+// and subtests governed by t. When t ends, the database is cleaned up.
+// If opts == nil, default options are used (see DBOptions).
+func NewDB(t *testing.T, opts *DBOptions) *DB {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "test.db")
+	key := &testutil.DummyAEAD{Name: "setectest.DB." + t.Name()}
+	adb, err := db.Open(path, key, opts.auditWriter())
+	if err != nil {
+		t.Fatalf("Creating test DB: %v", err)
+	}
+	return &DB{
+		t:         t,
+		Path:      path,
+		Key:       key,
+		Actual:    adb,
+		Superuser: superuser(),
+	}
+}
+
+// MustPut adds the specified secret to the database or fails.
+func (db *DB) MustPut(caller db.Caller, name, value string) api.SecretVersion {
+	db.t.Helper()
+
+	v, err := db.Actual.Put(caller, name, []byte(value))
+	if err != nil {
+		db.t.Fatalf("Put %q=%q failed: %v", name, value, err)
+	}
+	return v
+}
+
+// MustGet returns the active version of the named secret or fails.
+func (db *DB) MustGet(caller db.Caller, name string) *api.SecretValue {
+	db.t.Helper()
+
+	v, err := db.Actual.Get(caller, name)
+	if err != nil {
+		db.t.Fatalf("Get %q failed: %v", name, err)
+	}
+	return v
+}
+
+// MustGetVersion returns the specified version of the named secret or fails.
+func (db *DB) MustGetVersion(caller db.Caller, name string, version api.SecretVersion) *api.SecretValue {
+	db.t.Helper()
+
+	v, err := db.Actual.GetVersion(caller, name, version)
+	if err != nil {
+		db.t.Fatalf("GetVersion %v of %q failed: %v", version, name, err)
+	}
+	return v
+}
+
+// MustSetActiveVersion sets the active version of the named secret or fails.
+func (db *DB) MustSetActiveVersion(caller db.Caller, name string, version api.SecretVersion) {
+	db.t.Helper()
+
+	if err := db.Actual.SetActiveVersion(caller, name, version); err != nil {
+		db.t.Fatalf("SetActiveVersion %v of %q failed: %v", version, name, err)
+	}
+}
+
+// MustList lists the contents of the database or fails.
+func (db *DB) MustList(caller db.Caller) []*api.SecretInfo {
+	db.t.Helper()
+
+	vs, err := db.Actual.List(caller)
+	if err != nil {
+		db.t.Fatalf("List failed: %v", err)
+	}
+	return vs
+}

--- a/setectest/server.go
+++ b/setectest/server.go
@@ -1,0 +1,114 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Package setectest implements a wrapper around setec types for testing.
+//
+// # Usage
+//
+//	// Construct a database and add some secrets.
+//	db := setecttest.NewDB(t, nil)  // nil for default options
+//	db.MustPut(db.Superuser, "name", "value")
+//
+//	// Construct a test server.
+//	ss := setectest.NewServer(t, db, &setectest.ServerOptions{
+//	  WhoIs: setectest.AllAccess,
+//	})
+//
+//	// Hook up the Server to the httptest package.
+//	hs := httptest.NewServer(ss.Mux)
+package setectest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/tailscale/setec/acl"
+	"github.com/tailscale/setec/audit"
+	"github.com/tailscale/setec/server"
+	"tailscale.com/client/tailscale/apitype"
+	"tailscale.com/tailcfg"
+)
+
+// Server is a wrapper to support running a standalone setec Server for unit
+// tests with the testing package.
+type Server struct {
+	Actual *server.Server // the underlying server
+	Mux    *http.ServeMux // the serving mux populated by the server
+}
+
+// ServerOptions are options for constructing a test server.
+// A nil *ServerOptions is ready for use and provides defaults as described.
+type ServerOptions struct {
+	// WhoIs is a function implementing the corresponding method of a local
+	// client. If nil, setectest.AllAccess is used by default.
+	WhoIs func(context.Context, string) (*apitype.WhoIsResponse, error)
+
+	// AuditLog is where audit logs are written; if nil, audit logs are
+	// discarded without error.
+	AuditLog *audit.Writer
+}
+
+func (o *ServerOptions) whoIs() func(context.Context, string) (*apitype.WhoIsResponse, error) {
+	if o == nil || o.WhoIs == nil {
+		return AllAccess
+	}
+	return o.WhoIs
+}
+
+func (o *ServerOptions) auditLog() *audit.Writer {
+	if o == nil || o.AuditLog == nil {
+		return audit.New(io.Discard)
+	}
+	return o.AuditLog
+}
+
+// NewServer constructs a new Server that reads data from db and persists for
+// the duration of the test and subtests governed by t. When t ends, the server
+// and its database are cleaned up. If opts == nil, default options are used
+// (see ServerOptions).
+func NewServer(t *testing.T, db *DB, opts *ServerOptions) *Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	s, err := server.New(server.Config{
+		DBPath:   db.Path,
+		Key:      db.Key,
+		AuditLog: opts.auditLog(),
+		WhoIs:    opts.whoIs(),
+		Mux:      mux,
+	})
+	if err != nil {
+		t.Fatalf("Creating new server: %v", err)
+	}
+	return &Server{Actual: s, Mux: mux}
+}
+
+// allAccessCap is an encoded JSON capability for full access to all secrets.
+var allAccessCap []json.RawMessage
+
+func init() {
+	rule, err := json.Marshal(acl.Rule{
+		Action: []acl.Action{
+			acl.ActionGet, acl.ActionInfo, acl.ActionPut, acl.ActionSetActive, acl.ActionDelete,
+		},
+		Secret: []acl.Secret{"*"},
+	})
+	if err != nil {
+		panic(err)
+	}
+	allAccessCap = []json.RawMessage{rule}
+}
+
+// AllAccess is a WhoIs function implementation that returns a successful
+// response containing a capability for full access to all secrets.
+func AllAccess(ctx context.Context, addr string) (*apitype.WhoIsResponse, error) {
+	return &apitype.WhoIsResponse{
+		Node: &tailcfg.Node{Name: "example.com"},
+		UserProfile: &tailcfg.UserProfile{
+			ID: 666, LoginName: "user@example.com", DisplayName: "Example User",
+		},
+		CapMap: tailcfg.PeerCapMap{server.ACLCap: allAccessCap},
+	}, nil
+}


### PR DESCRIPTION
This package contains a plug-compatible wrapper around server.Server and db.DB
for use with the httptest package to serve secrets in unit tests.

Pulls the unexported testDB wrapper out of the db_test package into an exported
type, and updates the existing tests to use the new thing. Add a Server wrapper
to do the same for the HTTP plumbing, and include some affordances for setup.
