### PR TITLE
server,db: add support for deletion of secrets

### DIFF
--- a/db/db_test.go
+++ b/db/db_test.go
@@ -232,7 +232,7 @@ func TestDelete(t *testing.T) {
 	id := d.Superuser
 
 	const testName = "test-secret-name"
-	d.MustPut(id, testName, "ver1")
+	v1 := d.MustPut(id, testName, "ver1")
 
 	// Case 1: Deleting a secret that isn't there should succeed.
 	if err := d.Actual.Delete(id, "nonesuch"); err != nil {
@@ -242,6 +242,11 @@ func TestDelete(t *testing.T) {
 	// Case 2: Deleting a secret that exists should succeed.
 	if err := d.Actual.Delete(id, testName); err != nil {
 		t.Errorf("Delete %q: got %v, want nil", testName, err)
+	}
+
+	// Case 3: After deleting, we cannot retrieve the secret.
+	if got, err := d.Actual.GetVersion(id, testName, v1); !errors.Is(err, db.ErrNotFound) {
+		t.Errorf("GetVersion %v: got (%v, %v), want %v", v1, got, err, db.ErrNotFound)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -73,6 +73,8 @@ func New(cfg Config) (*Server, error) {
 	cfg.Mux.HandleFunc("/api/info", ret.info)
 	cfg.Mux.HandleFunc("/api/put", ret.put)
 	cfg.Mux.HandleFunc("/api/set-active", ret.setActive)
+	cfg.Mux.HandleFunc("/api/delete", ret.deleteSecret)
+	cfg.Mux.HandleFunc("/api/delete-version", ret.deleteVersion)
 
 	return ret, nil
 }
@@ -121,6 +123,20 @@ func (s *Server) setActive(w http.ResponseWriter, r *http.Request) {
 			return struct{}{}, err
 		}
 		return struct{}{}, nil
+	})
+}
+
+func (s *Server) deleteVersion(w http.ResponseWriter, r *http.Request) {
+	serveJSON(s, w, r, func(req api.DeleteVersionRequest, id db.Caller) (struct{}, error) {
+		err := s.db.DeleteVersion(id, req.Name, req.Version)
+		return struct{}{}, err
+	})
+}
+
+func (s *Server) deleteSecret(w http.ResponseWriter, r *http.Request) {
+	serveJSON(s, w, r, func(req api.DeleteRequest, id db.Caller) (struct{}, error) {
+		err := s.db.Delete(id, req.Name)
+		return struct{}{}, err
 	})
 }
 

--- a/types/api/api.go
+++ b/types/api/api.go
@@ -77,3 +77,19 @@ type SetActiveRequest struct {
 	// Version is the version to make active.
 	Version SecretVersion
 }
+
+// DeleteRequest is a request to delete all versions of a secret.
+type DeleteRequest struct {
+	// Name is the name of the secret to delete.
+	Name string
+}
+
+// DeleteVersionRequest is a request to delete a single version of a secret.
+type DeleteVersionRequest struct {
+	// Name is the name of the secret to delete a version from.
+	Name string
+
+	// Version is the version to delete; 0 is invalid for this request as the
+	// active version cannot be deleted.
+	Version SecretVersion
+}


### PR DESCRIPTION
This adds two new API methods:

- /api/delete: deletes all versions of a named secret
- /api/delete-version: deletes one non-active version of a secret

Components:

- db: add deletion methods to the kv type
- db: add database methods for deletion

  Delete: remove all versions of the specified secret.
  DeleteVersion: remove one (non-active) version of a single secret.

- db: add deletion tests
- api: add deletion request types
- server: add API handlers for deletion
