### PR TITLE
api,server: add support for conditional "get" requests

### DIFF
--- a/client/setec/store.go
+++ b/client/setec/store.go
@@ -225,8 +225,10 @@ func (s *Store) poll(ctx context.Context, updates map[string]*api.SecretValue) e
 	defer s.active.RUnlock()
 	var errs []error
 	for name, cv := range s.active.m {
-		sv, err := s.client.Get(ctx, name)
-		if err != nil {
+		sv, err := s.client.GetIfChanged(ctx, name, cv.Version)
+		if errors.Is(err, api.ErrValueNotChanged) {
+			continue // all is well, but nothing to update
+		} else if err != nil {
 			errs = append(errs, err)
 			continue
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package server_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/tailscale/setec/client/setec"
+	"github.com/tailscale/setec/setectest"
+	"github.com/tailscale/setec/types/api"
+)
+
+func TestServerGetChanged(t *testing.T) {
+	d := setectest.NewDB(t, nil)
+	v1 := d.MustPut(d.Superuser, "test", "v1") // active
+	v2 := d.MustPut(d.Superuser, "test", "v2")
+
+	ss := setectest.NewServer(t, d, nil)
+	hs := httptest.NewServer(ss.Mux)
+	defer hs.Close()
+
+	ctx := context.Background()
+	cli := setec.Client{Server: hs.URL, DoHTTP: hs.Client().Do}
+
+	// Case 1: Fetch the active value of the secret (v1).
+	sv1, err := cli.Get(ctx, "test")
+	if err != nil {
+		t.Fatalf("Get test: %v", err)
+	} else if sv1.Version != v1 {
+		t.Errorf("Get test: got version %v, want %v", sv1.Version, v1)
+	}
+
+	// Case 2: Fetch only if the value changed (which it did not).
+	sv2, err := cli.GetIfChanged(ctx, "test", sv1.Version)
+	if !errors.Is(err, api.ErrValueNotChanged) {
+		t.Errorf("GetIfChanged: got (%v, %v), want %v", sv2, err, api.ErrValueNotChanged)
+	}
+
+	// Now change the value on the server...
+	if err := cli.SetActiveVersion(ctx, "test", v2); err != nil {
+		t.Fatalf("SetActiveVersion %v: unexpected error: %v", v2, err)
+	}
+
+	// Case 3: Fetch only if the value changed (which it did).
+	sv3, err := cli.GetIfChanged(ctx, "test", sv1.Version)
+	if err != nil {
+		t.Errorf("GetIfChanged: unexpected error: %v", err)
+	} else if sv3.Version != v2 {
+		t.Errorf("GetIfChanged: got version %v, want %v", sv3.Version, v2)
+	}
+}

--- a/types/api/api.go
+++ b/types/api/api.go
@@ -5,7 +5,14 @@
 // server.
 package api
 
-import "strconv"
+import (
+	"errors"
+	"strconv"
+)
+
+// ErrValueNotChanged is a sentinel error reported by Get requests when the
+// secret value has not changed from the specified value.
+var ErrValueNotChanged = errors.New("value not changed")
 
 // SecretVersion is the version of a secret.
 //
@@ -50,9 +57,19 @@ type ListRequest struct{}
 type GetRequest struct {
 	// Name is the name of the secret to fetch.
 	Name string
-	// Version is the version to fetch, or SecretVersionDefault to let
-	// the server pick a version.
+
+	// Version is the version to fetch, or SecretVersionDefault to specify that
+	// the server should return the latest active version.
 	Version SecretVersion
+
+	// UpdateIfChanged, if true, instructs the server to return the latest
+	// active version of the secret if (and only if) the latest active version
+	// is different from Version. If the latest active version is equal to
+	// Version, the server reports 304 Not Modified and returns no value.
+	//
+	// If Version == SecretVersionDefault, this flag is ignored and the latest
+	// active version is returned unconditionally.
+	UpdateIfChanged bool
 }
 
 // InfoRequest is a request for secret metadata.


### PR DESCRIPTION
Extend api.GetRequest to include a digest field for an existing value of the
secret the caller knows about. If this field is set, the server will now check
whether the current active version matches this digest, and if so it will not
report a value back to the caller but will send 304 Not Modified.

The client unpacks this status into a sentinel error so the caller can check
for it without having to know about HTTP.
