### PR TITLE
client: add a Watcher type for secret values

### DIFF
--- a/client/setec/store.go
+++ b/client/setec/store.go
@@ -195,9 +195,6 @@ func (s *Store) Close() error {
 func (s *Store) Secret(name string) Secret {
 	s.active.Lock()
 	defer s.active.Unlock()
-	if _, ok := s.active.m[name]; !ok {
-		return nil // unknown secret
-	}
 	return s.secretLocked(name)
 }
 

--- a/client/setec/store.go
+++ b/client/setec/store.go
@@ -33,6 +33,7 @@ type Store struct {
 
 		m map[string]*api.SecretValue // :: secret name → active value
 		f map[string]Secret           // :: secret name → fetch function
+		w map[string][]Watcher        // :: secret name → watchers
 	}
 
 	cancel context.CancelFunc // stops the polling task
@@ -142,6 +143,7 @@ func NewStore(ctx context.Context, cfg StoreConfig) (*Store, error) {
 	// Initialize the active versions maps.
 	s.active.m = make(map[string]*api.SecretValue)
 	s.active.f = make(map[string]Secret)
+	s.active.w = make(map[string][]Watcher)
 
 	// If we have a cache, try to load data from there first.
 	data, err := s.loadCache()
@@ -196,6 +198,13 @@ func (s *Store) Secret(name string) Secret {
 	if _, ok := s.active.m[name]; !ok {
 		return nil // unknown secret
 	}
+	return s.secretLocked(name)
+}
+
+func (s *Store) secretLocked(name string) Secret {
+	if _, ok := s.active.m[name]; !ok {
+		return nil // unknown secret
+	}
 	f, ok := s.active.f[name]
 	if !ok {
 		f = func() []byte {
@@ -207,6 +216,20 @@ func (s *Store) Secret(name string) Secret {
 		s.active.f[name] = f
 	}
 	return f
+}
+
+// Watcher returns a watcher for the named secret. It returns a zero Watcher if
+// name does not correspond to one of the secrets known by s.
+func (s *Store) Watcher(name string) Watcher {
+	s.active.Lock()
+	defer s.active.Unlock()
+	secret := s.secretLocked(name)
+	if secret == nil {
+		return Watcher{}
+	}
+	w := Watcher{ready: make(chan struct{}, 1), secret: secret}
+	s.active.w[name] = append(s.active.w[name], w)
+	return w
 }
 
 // A Secret is a function that fetches the current active value of a secret.
@@ -288,6 +311,11 @@ func (s *Store) applyUpdates(updates map[string]*api.SecretValue) error {
 	defer s.active.Unlock()
 	for name, sv := range updates {
 		s.active.m[name] = sv
+
+		// Wake up any watchers pending on new values for this secret.
+		for _, w := range s.active.w[name] {
+			w.notify()
+		}
 	}
 	return s.flushCacheLocked()
 }
@@ -355,8 +383,7 @@ func (s *Store) initializeActive(ctx context.Context) error {
 	}
 }
 
-// A PollTicker is used to inject time control in to the polling loop of a
-// store.
+// A Ticker is used to inject time control in to the polling loop of a store.
 type Ticker interface {
 	// Chan returns a channel upon which time values are delivered to signal
 	// that a poll is required.
@@ -376,3 +403,28 @@ type stdTicker struct{ *time.Ticker }
 
 func (s stdTicker) Chan() <-chan time.Time { return s.Ticker.C }
 func (stdTicker) Done()                    {}
+
+// A Watcher monitors the current active value of a secret, and allows the user
+// to be notified when the value of the secret changes.
+type Watcher struct {
+	ready  chan struct{}
+	secret Secret
+}
+
+// Get returns the current active value of the secret.
+func (w Watcher) Get() []byte { return w.secret.Get() }
+
+// Ready returns a channel that delivers a value when the current active
+// version of the secret has changed. The channel is never closed.
+//
+// The ready channel is a level trigger. The Watcher does not queue multiple
+// notifications, and if the caller does not drain the channel subsequent
+// notifications will be dropped.
+func (w Watcher) Ready() <-chan struct{} { return w.ready }
+
+func (w Watcher) notify() {
+	select {
+	case w.ready <- struct{}{}:
+	default:
+	}
+}

--- a/client/setec/store_test.go
+++ b/client/setec/store_test.go
@@ -273,6 +273,64 @@ func TestSlowInit(t *testing.T) {
 	checkSecretValue(t, st, "boo", "go for the eyes")
 }
 
+func TestWatcher(t *testing.T) {
+	d := setectest.NewDB(t, nil)
+	d.MustPut(d.Superuser, "green", "eggs and ham") // active
+	v2 := d.MustPut(d.Superuser, "green", "grow the rushes oh")
+
+	ts := setectest.NewServer(t, d, nil)
+	hs := httptest.NewServer(ts.Mux)
+	defer hs.Close()
+
+	ctx := context.Background()
+	cli := setec.Client{Server: hs.URL, DoHTTP: hs.Client().Do}
+
+	pollTicker := newFakeTicker()
+	st, err := setec.NewStore(ctx, setec.StoreConfig{
+		Client:     cli,
+		Secrets:    []string{"green"},
+		PollTicker: pollTicker,
+	})
+	if err != nil {
+		t.Fatalf("NewStore: unexpected error: %v", err)
+	}
+	defer st.Close()
+
+	// Observe the initial value of the secret.
+	w := st.Watcher("green")
+	if got, want := string(w.Get()), "eggs and ham"; got != want {
+		t.Errorf("Initial value: got %q, want %q", got, want)
+	}
+
+	// The secret gets updated...
+	if err := cli.SetActiveVersion(ctx, "green", v2); err != nil {
+		t.Fatalf("SetActiveVersion to %v: unexpected error: %v", v2, err)
+	}
+
+	// The next poll occurs...
+	pollTicker.Poll()
+
+	// The watcher should get notified in a timely manner.
+	select {
+	case <-w.Ready():
+		t.Logf("✓ A new version of the secret is available")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timed out waiting for a watcher update")
+	}
+
+	if got, want := string(w.Get()), "grow the rushes oh"; got != want {
+		t.Errorf("Updated value: got %q, want %q", got, want)
+	}
+
+	// With no updates, the watchers should not appear ready.
+	select {
+	case <-w.Ready():
+		t.Error("Watcher is unexpectedly ready after no update")
+	case <-time.After(100 * time.Millisecond):
+		// OK
+	}
+}
+
 type badCache struct{}
 
 func (badCache) Write([]byte) error    { return errors.New("write failed") }


### PR DESCRIPTION
For clients that need to be notified when a new secret value is available, the
Watcher encapsulates a Secret with a level-triggered notification channel.
