### PR TITLE
all: rename "set-active" to "activate" throughout

### DIFF
--- a/acl/acl.go
+++ b/acl/acl.go
@@ -17,11 +17,11 @@ import (
 type Action string
 
 const (
-	ActionGet       = Action("get")
-	ActionInfo      = Action("info")
-	ActionPut       = Action("put")
-	ActionSetActive = Action("set-active")
-	ActionDelete    = Action("delete")
+	ActionGet      = Action("get")
+	ActionInfo     = Action("info")
+	ActionPut      = Action("put")
+	ActionActivate = Action("activate")
+	ActionDelete   = Action("delete")
 )
 
 // Secret is a secret name pattern that can optionally contain '*'

--- a/acl/acl_test.go
+++ b/acl/acl_test.go
@@ -16,7 +16,7 @@ func TestACL(t *testing.T) {
 			Secret: []acl.Secret{"control/foo", "control/bar"},
 		},
 		acl.Rule{
-			Action: []acl.Action{acl.ActionInfo, acl.ActionPut, acl.ActionSetActive},
+			Action: []acl.Action{acl.ActionInfo, acl.ActionPut, acl.ActionActivate},
 			Secret: []acl.Secret{"*"},
 		},
 		acl.Rule{
@@ -55,11 +55,11 @@ func TestACL(t *testing.T) {
 		allow("put", "something/else"),
 		allow("put", "dev/foo"),
 
-		allow("set-active", "control/foo"),
-		allow("set-active", "control/bar"),
-		allow("set-active", "control/quux"),
-		allow("set-active", "something/else"),
-		allow("set-active", "dev/foo"),
+		allow("activate", "control/foo"),
+		allow("activate", "control/bar"),
+		allow("activate", "control/quux"),
+		allow("activate", "something/else"),
+		allow("activate", "dev/foo"),
 
 		allow("delete", "dev/foo"),
 		allow("delete", "dev/bar/quux"),

--- a/client/setec/client.go
+++ b/client/setec/client.go
@@ -134,10 +134,9 @@ func (c *Client) Put(ctx context.Context, name string, value []byte) (version ap
 	})
 }
 
-// SetActiveVersion changes the active version of the secret called
-// name to version.
-func (c *Client) SetActiveVersion(ctx context.Context, name string, version api.SecretVersion) error {
-	_, err := do[struct{}](ctx, c, "/api/set-active", api.SetActiveRequest{
+// Activate changes the active version of the secret called name to version.
+func (c *Client) Activate(ctx context.Context, name string, version api.SecretVersion) error {
+	_, err := do[struct{}](ctx, c, "/api/activate", api.ActivateRequest{
 		Name:    name,
 		Version: version,
 	})

--- a/client/setec/store_test.go
+++ b/client/setec/store_test.go
@@ -120,7 +120,7 @@ func TestCachedStore(t *testing.T) {
 	d := setectest.NewDB(t, nil)
 	d.MustPut(d.Superuser, "alpha", "foobar")
 	v2 := d.MustPut(d.Superuser, "alpha", "bazquux")
-	d.MustSetActiveVersion(d.Superuser, "alpha", v2)
+	d.MustActivate(d.Superuser, "alpha", v2)
 
 	ts := setectest.NewServer(t, d, nil)
 	hs := httptest.NewServer(ts.Mux)
@@ -303,8 +303,8 @@ func TestWatcher(t *testing.T) {
 	}
 
 	// The secret gets updated...
-	if err := cli.SetActiveVersion(ctx, "green", v2); err != nil {
-		t.Fatalf("SetActiveVersion to %v: unexpected error: %v", v2, err)
+	if err := cli.Activate(ctx, "green", v2); err != nil {
+		t.Fatalf("Activate to %v: unexpected error: %v", v2, err)
 	}
 
 	// The next poll occurs...

--- a/cmd/setec/setec.go
+++ b/cmd/setec/setec.go
@@ -98,10 +98,10 @@ the user is prompted for a new value and confirmation at the terminal.`,
 				Run:      command.Adapt(runPut),
 			},
 			{
-				Name:  "set-active",
+				Name:  "activate",
 				Usage: "<server> <secret-name> <secret-version>",
 				Help:  "Set the active version of the specified secret.",
-				Run:   command.Adapt(runSetActive),
+				Run:   command.Adapt(runActivate),
 			},
 			command.HelpCommand(nil),
 		},
@@ -348,7 +348,7 @@ func runPut(env *command.Env, server, name string) error {
 	return nil
 }
 
-func runSetActive(env *command.Env, server, name, versionString string) error {
+func runActivate(env *command.Env, server, name, versionString string) error {
 	c := newClient(server)
 
 	version, err := strconv.ParseUint(versionString, 10, 32)
@@ -356,7 +356,7 @@ func runSetActive(env *command.Env, server, name, versionString string) error {
 		return fmt.Errorf("invalid version %q: %w", version, err)
 	}
 
-	if err := c.SetActiveVersion(env.Context(), name, api.SecretVersion(version)); err != nil {
+	if err := c.Activate(env.Context(), name, api.SecretVersion(version)); err != nil {
 		return fmt.Errorf("failed to set active version: %w", err)
 	}
 

--- a/db/db.go
+++ b/db/db.go
@@ -230,13 +230,12 @@ func (db *DB) putConfigLocked(name string, value []byte) (api.SecretVersion, err
 	}
 }
 
-// SetActiveVersion changes the active version of the secret called
-// name to version.
-func (db *DB) SetActiveVersion(caller Caller, name string, version api.SecretVersion) error {
+// Activate changes the active version of the secret called name to version.
+func (db *DB) Activate(caller Caller, name string, version api.SecretVersion) error {
 	if name == "" {
 		return errors.New("empty secret name")
 	}
-	if err := db.checkAndLog(caller, acl.ActionSetActive, name, version); err != nil {
+	if err := db.checkAndLog(caller, acl.ActionActivate, name, version); err != nil {
 		return err
 	}
 

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -91,7 +91,7 @@ func TestList(t *testing.T) {
 		},
 	})
 
-	d.MustSetActiveVersion(id, "test", 2)
+	d.MustActivate(id, "test", 2)
 	checkList(d.Actual, []*api.SecretInfo{
 		{
 			Name:          "test",
@@ -148,7 +148,7 @@ func TestGet(t *testing.T) {
 			t.Fatalf("secret version %d is %q, want %q", v, sec.Value, want)
 		}
 
-		d.MustSetActiveVersion(id, "test", v)
+		d.MustActivate(id, "test", v)
 		sec = d.MustGet(id, "test")
 		if !bytes.Equal(sec.Value, want) {
 			t.Fatalf("active secret is %q, want %q", sec.Value, want)

--- a/server/server.go
+++ b/server/server.go
@@ -94,7 +94,7 @@ func New(cfg Config) (*Server, error) {
 	cfg.Mux.HandleFunc("/api/get", ret.get)
 	cfg.Mux.HandleFunc("/api/info", ret.info)
 	cfg.Mux.HandleFunc("/api/put", ret.put)
-	cfg.Mux.HandleFunc("/api/set-active", ret.setActive)
+	cfg.Mux.HandleFunc("/api/activate", ret.activate)
 	cfg.Mux.HandleFunc("/api/delete", ret.deleteSecret)
 	cfg.Mux.HandleFunc("/api/delete-version", ret.deleteVersion)
 
@@ -180,9 +180,9 @@ func (s *Server) put(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (s *Server) setActive(w http.ResponseWriter, r *http.Request) {
-	serveJSON(s, w, r, func(req api.SetActiveRequest, id db.Caller) (struct{}, error) {
-		if err := s.db.SetActiveVersion(id, req.Name, req.Version); err != nil {
+func (s *Server) activate(w http.ResponseWriter, r *http.Request) {
+	serveJSON(s, w, r, func(req api.ActivateRequest, id db.Caller) (struct{}, error) {
+		if err := s.db.Activate(id, req.Name, req.Version); err != nil {
 			return struct{}{}, err
 		}
 		return struct{}{}, nil

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -41,7 +41,7 @@ func TestServerGetChanged(t *testing.T) {
 	}
 
 	// Now change the value on the server...
-	if err := cli.SetActiveVersion(ctx, "test", v2); err != nil {
+	if err := cli.Activate(ctx, "test", v2); err != nil {
 		t.Fatalf("SetActiveVersion %v: unexpected error: %v", v2, err)
 	}
 

--- a/setectest/dbtest.go
+++ b/setectest/dbtest.go
@@ -30,7 +30,7 @@ func superuser() db.Caller {
 		Permissions: acl.Rules{
 			acl.Rule{
 				Action: []acl.Action{
-					acl.ActionGet, acl.ActionInfo, acl.ActionPut, acl.ActionSetActive, acl.ActionDelete,
+					acl.ActionGet, acl.ActionInfo, acl.ActionPut, acl.ActionActivate, acl.ActionDelete,
 				},
 				Secret: []acl.Secret{"*"},
 			},
@@ -118,11 +118,11 @@ func (db *DB) MustGetVersion(caller db.Caller, name string, version api.SecretVe
 	return v
 }
 
-// MustSetActiveVersion sets the active version of the named secret or fails.
-func (db *DB) MustSetActiveVersion(caller db.Caller, name string, version api.SecretVersion) {
+// MustActivate sets the active version of the named secret or fails.
+func (db *DB) MustActivate(caller db.Caller, name string, version api.SecretVersion) {
 	db.t.Helper()
 
-	if err := db.Actual.SetActiveVersion(caller, name, version); err != nil {
+	if err := db.Actual.Activate(caller, name, version); err != nil {
 		db.t.Fatalf("SetActiveVersion %v of %q failed: %v", version, name, err)
 	}
 }

--- a/setectest/server.go
+++ b/setectest/server.go
@@ -91,7 +91,7 @@ var allAccessCap []json.RawMessage
 func init() {
 	rule, err := json.Marshal(acl.Rule{
 		Action: []acl.Action{
-			acl.ActionGet, acl.ActionInfo, acl.ActionPut, acl.ActionSetActive, acl.ActionDelete,
+			acl.ActionGet, acl.ActionInfo, acl.ActionPut, acl.ActionActivate, acl.ActionDelete,
 		},
 		Secret: []acl.Secret{"*"},
 	})

--- a/types/api/api.go
+++ b/types/api/api.go
@@ -86,9 +86,8 @@ type PutRequest struct {
 	Value []byte
 }
 
-// SetActiveRequest is a request to change the active version of a
-// secret.
-type SetActiveRequest struct {
+// ActivateRequest is a request to change the active version of a secret.
+type ActivateRequest struct {
 	// Name is the name of the secret to update.
 	Name string
 	// Version is the version to make active.


### PR DESCRIPTION
- api: rename "set-active" to "activate"
- server: rename /api/set-active to /api/active
- client, db: rename SetActiveVersion to Activate
- update test support and tests

Note this will require adjusting the ACLs when we do an import.

Signed-off-by: M. J. Fromberger <fromberger@tailscale.com>
