### PR TITLE
cmd/setec: add "delete" and "delete-version" subcommands

### DIFF
--- a/client/setec/client.go
+++ b/client/setec/client.go
@@ -142,3 +142,20 @@ func (c *Client) Activate(ctx context.Context, name string, version api.SecretVe
 	})
 	return err
 }
+
+// DeleteVersion deletes the specified version of the named secret.
+func (c *Client) DeleteVersion(ctx context.Context, name string, version api.SecretVersion) error {
+	_, err := do[struct{}](ctx, c, "/api/delete-version", api.DeleteVersionRequest{
+		Name:    name,
+		Version: version,
+	})
+	return err
+}
+
+// Delete deletes all versions of the named secret.
+func (c *Client) Delete(ctx context.Context, name string) error {
+	_, err := do[struct{}](ctx, c, "/api/delete", api.DeleteRequest{
+		Name: name,
+	})
+	return err
+}

--- a/cmd/setec/setec.go
+++ b/cmd/setec/setec.go
@@ -109,7 +109,7 @@ the user is prompted for a new value and confirmation at the terminal.`,
 				Usage: "<server> <secret-name> <secret-version> [<confirm-token>]",
 				Help: `Delete the specified non-active version of a secret.
 
-A onfirmation token is required to delete a secret value.  Run the command to
+A confirmation token is required to delete a secret value.  Run the command to
 generate the token, then re-run appending the provided value.`,
 
 				Run: command.Adapt(runDeleteVersion),
@@ -119,7 +119,7 @@ generate the token, then re-run appending the provided value.`,
 				Usage: "<server> <secret-name> [<confirm-token>]",
 				Help: `Delete all versions of a secret (including active).
 
-A onfirmation token is required to delete a secret.  Run the command to
+A confirmation token is required to delete a secret.  Run the command to
 generate the token, then re-run appending the provided value.`,
 
 				Run: command.Adapt(runDeleteSecret),

--- a/cmd/setec/setec.go
+++ b/cmd/setec/setec.go
@@ -437,14 +437,14 @@ func runDeleteSecret(env *command.Env, server, name string, rest ...string) erro
 // The token is not a security feature, it is just a request digest with a
 // timestamp to reduce the chances of things getting deleted by accident.
 func newConfirmationToken(req string) string {
-	// Code format: <time-window>-<req-digest>
+	// Code format: <time-window>.<req-digest>
 	//
 	// Confirmation codes last about 1 minute after construction, as a cheap
 	// hedge against copy-pasta from old script output or command history.  The
 	// digest is just to tie the token to the specific request.
 	window := (int64(time.Now().Unix()) + 119) / 60 // round up
 	sum := sha256.Sum256([]byte(req))
-	return fmt.Sprintf("%x-%x", window, sum[:8])
+	return fmt.Sprintf("%x.%x", window, sum[:8])
 }
 
 func checkConfirmation(req, token string) error {


### PR DESCRIPTION
Related changes:

- client: add methods to call these APIs
- cmd/setec: make handlers shut down cleanly on signal

Signed-off-by: M. J. Fromberger <fromberger@tailscale.com>
