### PR TITLE
all: report sentinel errors for common response categories

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -114,7 +114,7 @@ func TestServerStatus(t *testing.T) {
 	if err := cli.DeleteVersion(ctx, "ok/test", ov1); err == nil {
 		t.Errorf("DeleteVersion %v: unexpected success", ov1)
 	} else {
-		t.Logf("DeleteVersoin %v: got expected error: %v", ov1, err)
+		t.Logf("DeleteVersion %v: got expected error: %v", ov1, err)
 	}
 
 	// Case 5: Success for delete of ok/test inactive version.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -68,7 +68,7 @@ func TestServerStatus(t *testing.T) {
 	// Synthesize a selective access capability that permits read of secrets
 	// beginning with "ok/".
 	rule, err := json.Marshal(acl.Rule{
-		Action: []acl.Action{acl.ActionGet, acl.ActionInfo},
+		Action: []acl.Action{acl.ActionGet, acl.ActionInfo, acl.ActionDelete},
 		Secret: []acl.Secret{"ok/*"},
 	})
 	if err != nil {
@@ -110,17 +110,15 @@ func TestServerStatus(t *testing.T) {
 		t.Errorf("Put ok/test: got (%v, %v), want error %v", sv, err, api.ErrAccessDenied)
 	}
 
-	_ = ov1
-	/*
-		// Case 4: Access denied for delete of ok/test active version.
-		if err := cli.DeleteVersion(ctx, "ok/test", ov1); !errors.Is(err, api.ErrAccessDenied) {
-			t.Errorf("DeleteVersion %v: got error %v, want %v", ov1, err, api.ErrAccessDenied)
-		}
+	// Case 4: Internal error for delete of ok/test active version.
+	if err := cli.DeleteVersion(ctx, "ok/test", ov1); err == nil {
+		t.Errorf("DeleteVersion %v: unexpected success", ov1)
+	} else {
+		t.Logf("DeleteVersoin %v: got expected error: %v", ov1, err)
+	}
 
-		// Case 5: Success for delete of ok/test inactive version.
-		if err := cli.DeleteVersion(ctx, "ok/test", ov2); err != nil {
-			t.Errorf("DeleteVersion %v: unexpected error %v", ov2, err)
-		}
-	*/
-
+	// Case 5: Success for delete of ok/test inactive version.
+	if err := cli.DeleteVersion(ctx, "ok/test", ov2); err != nil {
+		t.Errorf("DeleteVersion %v: unexpected error %v", ov2, err)
+	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -5,13 +5,18 @@ package server_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/tailscale/setec/acl"
 	"github.com/tailscale/setec/client/setec"
+	"github.com/tailscale/setec/server"
 	"github.com/tailscale/setec/setectest"
 	"github.com/tailscale/setec/types/api"
+	"tailscale.com/client/tailscale/apitype"
+	"tailscale.com/tailcfg"
 )
 
 func TestServerGetChanged(t *testing.T) {
@@ -52,4 +57,70 @@ func TestServerGetChanged(t *testing.T) {
 	} else if sv3.Version != v2 {
 		t.Errorf("GetIfChanged: got version %v, want %v", sv3.Version, v2)
 	}
+}
+
+func TestServerStatus(t *testing.T) {
+	d := setectest.NewDB(t, nil)
+	ov1 := d.MustPut(d.Superuser, "ok/test", "v1") // active
+	ov2 := d.MustPut(d.Superuser, "ok/test", "v2")
+	nv1 := d.MustPut(d.Superuser, "no/test", "no") // active
+
+	// Synthesize a selective access capability that permits read of secrets
+	// beginning with "ok/".
+	rule, err := json.Marshal(acl.Rule{
+		Action: []acl.Action{acl.ActionGet, acl.ActionInfo},
+		Secret: []acl.Secret{"ok/*"},
+	})
+	if err != nil {
+		t.Fatalf("Create access grant: %v", err)
+	}
+	whois := &apitype.WhoIsResponse{
+		Node: &tailcfg.Node{Name: "example.com"},
+		UserProfile: &tailcfg.UserProfile{
+			ID: 31337, LoginName: "elite@example.com", DisplayName: "Leet Q. Haxor",
+		},
+		CapMap: tailcfg.PeerCapMap{server.ACLCap: []json.RawMessage{rule}},
+	}
+
+	ss := setectest.NewServer(t, d, &setectest.ServerOptions{
+		WhoIs: func(context.Context, string) (*apitype.WhoIsResponse, error) {
+			return whois, nil
+		},
+	})
+	hs := httptest.NewServer(ss.Mux)
+	defer hs.Close()
+
+	ctx := context.Background()
+	cli := setec.Client{Server: hs.URL, DoHTTP: hs.Client().Do}
+
+	// Note: Conditional get is exercised by TestServerGetChanged above.
+
+	// Case 1: Access denied for get of no/test.
+	if sv, err := cli.GetVersion(ctx, "no/test", nv1); !errors.Is(err, api.ErrAccessDenied) {
+		t.Errorf("GetVersion %v: got (%v, %v), want error %v", nv1, sv, err, api.ErrAccessDenied)
+	}
+
+	// Case 2: Not found for get of non-existing ok/test version.
+	if sv, err := cli.GetVersion(ctx, "ok/test", ov2+1); !errors.Is(err, api.ErrNotFound) {
+		t.Errorf("GetVersion %v: got (%v, %v), want error %v", ov2+1, sv, err, api.ErrNotFound)
+	}
+
+	// Case 3: Access denied for put of ok/test version.
+	if sv, err := cli.Put(ctx, "ok/test", []byte("ohai")); !errors.Is(err, api.ErrAccessDenied) {
+		t.Errorf("Put ok/test: got (%v, %v), want error %v", sv, err, api.ErrAccessDenied)
+	}
+
+	_ = ov1
+	/*
+		// Case 4: Access denied for delete of ok/test active version.
+		if err := cli.DeleteVersion(ctx, "ok/test", ov1); !errors.Is(err, api.ErrAccessDenied) {
+			t.Errorf("DeleteVersion %v: got error %v, want %v", ov1, err, api.ErrAccessDenied)
+		}
+
+		// Case 5: Success for delete of ok/test inactive version.
+		if err := cli.DeleteVersion(ctx, "ok/test", ov2); err != nil {
+			t.Errorf("DeleteVersion %v: unexpected error %v", ov2, err)
+		}
+	*/
+
 }

--- a/types/api/api.go
+++ b/types/api/api.go
@@ -10,9 +10,19 @@ import (
 	"strconv"
 )
 
-// ErrValueNotChanged is a sentinel error reported by Get requests when the
-// secret value has not changed from the specified value.
-var ErrValueNotChanged = errors.New("value not changed")
+var (
+	// ErrValueNotChanged is a sentinel error reported by Get requests when the
+	// secret value has not changed from the specified value.
+	ErrValueNotChanged = errors.New("value not changed")
+
+	// ErrNotFound is a sentinel error reported by requests when the specified
+	// secret version is not found.
+	ErrNotFound = errors.New("not found")
+
+	// ErrAccessDenied is a sentinel error reported by requests when access to
+	// perform the requested operation is denied.
+	ErrAccessDenied = errors.New("access denied")
+)
 
 // SecretVersion is the version of a secret.
 //


### PR DESCRIPTION
(downstream of #53)

A mild improvement to client ergonomics.

Add sentinel errors to the api package for "not found" and "access denied"
errors, so that users of the client can inspect for these error types.

Make the server encode "not found" errors as a 404 status instead of 500.  We
did not do this initially for concern about information leakage, but since we
do not get this error until we are already willing to vend the requested data
back to the caller (i.e., upon a successful authorization check), we are not
divulging anything they could not have already inferred.

Signed-off-by: M. J. Fromberger <fromberger@tailscale.com>
