### PR TITLE
client/setec: remove MustStaticFile

### DIFF
--- a/client/setec/store.go
+++ b/client/setec/store.go
@@ -338,15 +338,6 @@ func StaticFile(path string) (Secret, error) {
 	return func() []byte { return bs }, nil
 }
 
-// MustStaticFile is like StaticFile, but panics if the file cannot be read.
-func MustStaticFile(path string) Secret {
-	ret, err := StaticFile(path)
-	if err != nil {
-		panic(err)
-	}
-	return ret
-}
-
 // poll polls the service for the active version of each secret in s.active.m.
 // It populates updates with any secret values that have changed.
 func (s *Store) poll(ctx context.Context, updates map[string]*api.SecretValue) error {


### PR DESCRIPTION
Turns out the only place you can use it safely, is a place where you should be using StaticFile and handling the error gracefully.