### PR TITLE
go.mod: update command and flax dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.21
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.18.10
-	github.com/creachadair/command v0.1.0
-	github.com/creachadair/flax v0.0.0-20230825143830-824622abb99d
+	github.com/creachadair/command v0.1.2
+	github.com/creachadair/flax v0.0.0-20230904162121-7852fa2389bd
 	github.com/google/go-cmp v0.5.9
 	github.com/tink-crypto/tink-go-awskms v0.0.0-20230616072154-ba4f9f22c3e9
 	github.com/tink-crypto/tink-go/v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -62,10 +62,10 @@ github.com/coreos/go-iptables v0.6.0 h1:is9qnZMPYjLd8LYqmm/qlE+wwEgJIkTYdhV3rfZo
 github.com/coreos/go-iptables v0.6.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/coreos/go-systemd/v22 v22.4.0 h1:y9YHcjnjynCd/DVbg5j9L/33jQM3MxJlbj/zWskzfGU=
 github.com/coreos/go-systemd/v22 v22.4.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
-github.com/creachadair/command v0.1.0 h1:NP+4zBtRxsJDfe6zqCkPpIuYFb9/svSlvlaaAHqkUWo=
-github.com/creachadair/command v0.1.0/go.mod h1:hTu+WcX2tWwn3qgux8b26e6QKJZ7Tm45/5miXSdgxa4=
-github.com/creachadair/flax v0.0.0-20230825143830-824622abb99d h1:/oxRajOErR7TEvBt+HI2ns0bNjvctUbWmN6VD80ri9Y=
-github.com/creachadair/flax v0.0.0-20230825143830-824622abb99d/go.mod h1:2vVCsqiB+GpV/qBKCQ0lKRrJhlKUPdI83SnaFKwJyNo=
+github.com/creachadair/command v0.1.2 h1:WA1p96yyGCX1cHVuQjGW0Dsz4YqEeOSmildkDTBr5Eg=
+github.com/creachadair/command v0.1.2/go.mod h1:hTu+WcX2tWwn3qgux8b26e6QKJZ7Tm45/5miXSdgxa4=
+github.com/creachadair/flax v0.0.0-20230904162121-7852fa2389bd h1:Dd9zMOXj0B5bcCB9X0Hppy7IG8zlzet5PbYJUEQeIpU=
+github.com/creachadair/flax v0.0.0-20230904162121-7852fa2389bd/go.mod h1:2vVCsqiB+GpV/qBKCQ0lKRrJhlKUPdI83SnaFKwJyNo=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Fix a bug causing --help to be improperly ignored at the end of a command.
