### PR TITLE
client/setec: check cache validity after decoding

### DIFF
--- a/client/setec/store.go
+++ b/client/setec/store.go
@@ -188,6 +188,9 @@ func NewStore(ctx context.Context, cfg StoreConfig) (*Store, error) {
 		if err := json.Unmarshal(data, &s.active.m); err != nil {
 			s.logf("WARNING: error decoding cache: %v (continuing)", err)
 			clear(s.active.m) // reset
+		} else if !s.isActiveSetValid() {
+			s.logf("WARNING: cache is not valid; discarding it")
+			clear(s.active.m) // reset
 		}
 	}
 
@@ -533,6 +536,17 @@ func (s *Store) loadCache() ([]byte, error) {
 		return nil, nil
 	}
 	return s.cache.Read()
+}
+
+// isActiveSetValid reports whether the current active set is valid.
+// This is used during initializtion to check cache validity.
+func (s *Store) isActiveSetValid() bool {
+	for key, cs := range s.active.m {
+		if key == "" || cs == nil || cs.Secret == nil {
+			return false
+		}
+	}
+	return true
 }
 
 func sleepFor(ctx context.Context, d time.Duration) {

--- a/client/setec/store_test.go
+++ b/client/setec/store_test.go
@@ -204,6 +204,7 @@ func TestBadCache(t *testing.T) {
 	}{
 		{"ReadFailed", badCache{}},
 		{"DecodeFailed", setec.NewMemCache(`{"bad":JSON*#$&(@`)},
+		{"InvalidCache", setec.NewMemCache(`{"alpha":{"Value":"blah", "Version":100}}`)},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
When I changed the cache format, I intended that the old cache would simply
look invalid and be rejected. Because of the way JSON decoding works, though, a
valid JSON value in the wrong shape could result in a cache with invalid
entries.  Notably: An object with expected secret names but the wrong object
shape.

Fix this by explicitly checking for valid secrets after cache loading.
