### PR TITLE
client/setec: export a Refresh method on the Store

### DIFF
--- a/client/setec/store.go
+++ b/client/setec/store.go
@@ -241,6 +241,26 @@ func (s *Store) Close() error {
 	return nil
 }
 
+// Refresh synchronously checks for new versions of all the secrets currently
+// known by s. It blocks until the refresh is complete or until ctx ends.
+//
+// Updates are managed automatically when a Store is created and by the polling
+// mechanism, but a caller may invoke Refresh directly if it wants to check for
+// new secret values at a specific moment.
+func (s *Store) Refresh(ctx context.Context) error {
+	s.countPolls.Add(1)
+	s.latestPoll.Set(float64(time.Now().UTC().UnixMilli()) / 1000)
+	updates := make(map[string]*api.SecretValue)
+	if err := s.poll(ctx, updates); err != nil {
+		s.countPollErrors.Add(1)
+		return fmt.Errorf("[store] update poll failed: %w", err)
+	}
+	if err := s.applyUpdates(updates); err != nil {
+		return fmt.Errorf("[store] applying updates failed: %w", err)
+	}
+	return nil
+}
+
 // Secret returns a fetcher for the named secret. It returns nil if name does
 // not correspond to one of the secrets known by s.
 func (s *Store) Secret(name string) Secret {
@@ -463,15 +483,8 @@ func (s *Store) run(ctx context.Context, interval time.Duration, done chan<- str
 			}
 			return
 		case <-doPoll:
-			s.countPolls.Add(1)
-			s.latestPoll.Set(float64(time.Now().UTC().UnixMilli()) / 1000)
-			updates := make(map[string]*api.SecretValue)
-			if err := s.poll(ctx, updates); err != nil {
-				s.countPollErrors.Add(1)
-				s.logf("[store] update poll failed: %v (continuing)", err)
-			}
-			if err := s.applyUpdates(updates); err != nil {
-				s.logf("[store] applying updates failed: %v (continuing)", err)
+			if err := s.Refresh(ctx); err != nil {
+				s.logf("%s (continuing)", err)
 			}
 			t.Done()
 		}

--- a/client/setec/store.go
+++ b/client/setec/store.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/tailscale/setec/types/api"
+	"golang.org/x/sync/singleflight"
 	"tailscale.com/types/logger"
 )
 
@@ -27,6 +28,7 @@ type Store struct {
 	allowLookup bool
 	newTicker   func(time.Duration) Ticker
 	timeNow     func() time.Time
+	single      singleflight.Group
 
 	// Undeclared secrets not accessed in at least this long are eligible to be
 	// purged from the cache. If zero, no expiry is performed.
@@ -248,17 +250,20 @@ func (s *Store) Close() error {
 // mechanism, but a caller may invoke Refresh directly if it wants to check for
 // new secret values at a specific moment.
 func (s *Store) Refresh(ctx context.Context) error {
-	s.countPolls.Add(1)
-	s.latestPoll.Set(float64(time.Now().UTC().UnixMilli()) / 1000)
-	updates := make(map[string]*api.SecretValue)
-	if err := s.poll(ctx, updates); err != nil {
-		s.countPollErrors.Add(1)
-		return fmt.Errorf("[store] update poll failed: %w", err)
-	}
-	if err := s.applyUpdates(updates); err != nil {
-		return fmt.Errorf("[store] applying updates failed: %w", err)
-	}
-	return nil
+	_, err, _ := s.single.Do("poll", func() (any, error) {
+		s.countPolls.Add(1)
+		s.latestPoll.Set(float64(time.Now().UTC().UnixMilli()) / 1000)
+		updates := make(map[string]*api.SecretValue)
+		if err := s.poll(ctx, updates); err != nil {
+			s.countPollErrors.Add(1)
+			return nil, fmt.Errorf("[store] update poll failed: %w", err)
+		}
+		if err := s.applyUpdates(updates); err != nil {
+			return nil, fmt.Errorf("[store] applying updates failed: %w", err)
+		}
+		return nil, nil
+	})
+	return err
 }
 
 // Secret returns a fetcher for the named secret. It returns nil if name does

--- a/docs/README.md
+++ b/docs/README.md
@@ -336,6 +336,13 @@ rsp, err := getClient().Method(ctx, args)
 // ...
 ```
 
+In addition, if the program needs to explicitly refresh the values of secrets
+at a specific time (for example, in response to an operator signal or other
+event) it may explicitly call the `Store` value's [`Refresh`][strefresh]
+method, which effects a poll of all known secrets synchronously. It is safe for
+the client to do this concurrently with a background poll; the store will
+coalesce the operations.
+
 ### Bootstrapping and Availability
 
 A reasonable concern when fetching secrets from a network service is what
@@ -439,3 +446,4 @@ if err != nil {
 [setectest]: https://godoc.org/github.com/tailscale/setec/setectest
 [setecwatcher]: https://godoc.org/github.com/tailscale/setec/client/setec#Watcher
 [stserver]: https://godoc.org/github.com/tailscale/setec/setectest#Server
+[stserver]: https://godoc.org/github.com/tailscale/setec/client/setec#Store.Refresh

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/tink-crypto/tink-go-awskms v0.0.0-20230616072154-ba4f9f22c3e9
 	github.com/tink-crypto/tink-go/v2 v2.0.0
 	golang.org/x/exp v0.0.0-20230725093048-515e97ebf090
+	golang.org/x/sync v0.2.0
 	golang.org/x/term v0.11.0
 	tailscale.com v1.1.1-0.20230920164730-5f4d76c18c6d
 )
@@ -87,7 +88,6 @@ require (
 	golang.org/x/crypto v0.12.0 // indirect
 	golang.org/x/mod v0.11.0 // indirect
 	golang.org/x/net v0.14.0 // indirect
-	golang.org/x/sync v0.2.0 // indirect
 	golang.org/x/sys v0.11.0 // indirect
 	golang.org/x/text v0.12.0 // indirect
 	golang.org/x/time v0.3.0 // indirect


### PR DESCRIPTION
(A proposal for discussion)

Allow the program to explicitly check for new secret values at a specific
moment, e.g. in response to a signal or other operator-controlled input.
