### PR TITLE
fields: parse tagged fields in struct values and apply secrets to them

### DIFF
--- a/client/setec/example_test.go
+++ b/client/setec/example_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package setec_test
+
+import (
+	"context"
+	"flag"
+	"log"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/tailscale/setec/client/setec"
+	"github.com/tailscale/setec/setectest"
+	"tailscale.com/types/logger"
+)
+
+var runEnv = flag.String("env", "dev", "Runtime environment (dev or prod)")
+
+func TestExample(t *testing.T) {
+	// Set up plumbing for the example. In real usage, the client will typically
+	// communicate with a server running on another host.
+	d := setectest.NewDB(t, nil)
+	d.MustPut(d.Superuser, "dev/alpha", "dev-alpha")
+	d.MustPut(d.Superuser, "prod/alpha", "prod-alpha")
+	d.MustPut(d.Superuser, "dev/bravo", "dev-bravo")
+	d.MustPut(d.Superuser, "prod/bravo", "prod-bravo")
+	d.MustPut(d.Superuser, "dev/charlie", "dev-charlie")
+	d.MustPut(d.Superuser, "prod/charlie", "prod-charlie")
+	d.MustPut(d.Superuser, "dev/delta", `"2023-10-06T12:34:56Z"`)
+	d.MustPut(d.Superuser, "prod/delta", `"2023-10-05T01:23:45Z"`)
+
+	ts := setectest.NewServer(t, d, nil)
+	hs := httptest.NewServer(ts.Mux)
+	defer hs.Close()
+
+	// Example begins here:
+	setecClient := setec.Client{Server: hs.URL, DoHTTP: hs.Client().Do}
+
+	// Set up a struct type with fields to carry the secrets you care about.
+	var secrets struct {
+		Alpha   []byte       `setec:"alpha"`
+		Bravo   string       `setec:"bravo"`
+		Charlie setec.Secret `setec:"charlie"`
+		Delta   time.Time    `setec:"delta,json"`
+		Other   int          // this field is not touched by setec
+	}
+	secrets.Other = 25
+
+	// Create a setec.Store to track those secrets.  Use the --env flag to
+	// select which set of secrets will be populated ("dev" or "prod").
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	st, err := setec.NewStore(ctx, setec.StoreConfig{
+		Client:  setecClient,
+		Structs: []setec.Struct{{Value: &secrets, Prefix: *runEnv}},
+		Logf:    logger.Discard,
+	})
+	if err != nil {
+		log.Fatalf("NewStore: %v", err)
+	}
+	defer st.Close()
+
+	// At this point the field values have been populated.
+	t.Logf("Example values:\nalpha: %q\nbravo: %q\ncharlie: %q\ndelta: %v\nother: %d\n",
+		secrets.Alpha, secrets.Bravo, secrets.Charlie.Get(), secrets.Delta, secrets.Other)
+}

--- a/client/setec/fields.go
+++ b/client/setec/fields.go
@@ -1,0 +1,230 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package setec
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path"
+	"reflect"
+	"strings"
+
+	"golang.org/x/exp/slices"
+)
+
+// ParseFields parses information about setec-tagged fields from v. The
+// concrete type of v must be a pointer to a struct value with at least one
+// tagged field.  The namePrefix, if non-empty, is joined to the front of each
+// tagged name, separated with a slash ("/").
+//
+// See [Fields] for a description of the struct tags and types recognized.
+func ParseFields(v any, namePrefix string) (*Fields, error) {
+	fi, err := parseFields(v)
+	if err != nil {
+		return nil, err
+	}
+	if len(fi) == 0 {
+		return nil, fmt.Errorf("type %v has no setec-tagged fields", reflect.TypeOf(v).Elem())
+	}
+	return &Fields{prefix: namePrefix, fields: fi}, nil
+}
+
+// Fields is a helper for plumbing secrets to the fields of struct values.  The
+// [ParseFields] function recognizes fields of a struct with a tag like:
+//
+//	setec:"base-secret-name[,json]"
+//
+// The resulting Fields value fetches the secrets identified by these tags from
+// a setec.Store, and injects their values into the fields.
+//
+// # Background
+//
+// A program that uses multiple secret values has to plumb those secrets down
+// to the code that needs them. One way to manage this is to bundle the secrets
+// together into fields of a struct, and to make that struct accessible via a
+// shared configuration library or through a context argument.
+//
+// To simplify the manual process of adding fields and hooking them up to the
+// secrets service, the Fields type uses reflection to discover the names of
+// secrets declared via struct tags, and to handle the boilerplate of plumbing
+// secret values to those fields.
+//
+// # Basic usage
+//
+// Populate the Structs field of the [StoreConfig] with pointers to the struct
+// values to be populated. You may optionally provide a prefix to prepend to
+// secret names, so that it can use different secrets in different environments
+// (for example dev vs. prod):
+//
+//	st, err := setec.NewStore(ctx, setec.StoreConfig{
+//	   Client:  client,
+//	   Structs: []setec.Struct{{Value: &v, Prefix: "dev/program-name"}},
+//	})
+//	// ...
+//
+// Once the store is ready, the secret values are automatically copied to the
+// corresponding fields. It is also possible to explicitly populate struct
+// fields after the store is constructed, see [ParseFields]. The store must be
+// constructed with the AllowLookup option enabled to add new secrets after the
+// store has been constructed.
+//
+// # Field Types
+//
+// The Fields type can handle struct fields of the following types:
+//
+//   - A field of type []byte receives a copy of the secret value.
+//   - A field of type string receives a copy of the secret as a string.
+//   - A field of type [setec.Secret] is populated with a handle to the secret.
+//   - A field of type [setec.Watcher] is populated with a watcher for the secret.
+//
+// In addition, a field may have any type that supports JSON encoding, provided
+// the secret value is also encoded as JSON, if its tag includes the optional
+// "json" verb. For example, given:
+//
+//	type Key struct {
+//	   Salt []byte `json:"iv"`
+//	   Data []byte `json:"data"`
+//	}
+//
+// the following is a valid field declaration:
+//
+//	SecretKey Key `setec:"secret-key,json"`  // note "json" verb
+//
+// and accepts a secret value formatted like:
+//
+//	{"iv":"aGVsbG8sIHdvcmxk","data":"c3VwZXIgc2VjcmV0IHNxdWlycmVsIHN0dWZm"}
+//
+// The ParseFields function will report an error for a tagged field whose type
+// does not fit within these constraints.
+type Fields struct {
+	prefix string      // empty means "no prefix"
+	fields []fieldInfo // fields needing populated
+}
+
+// Secrets returns the full prefix-expanded names of the secrets needed by
+// fields tagged in f.
+func (f *Fields) Secrets() []string {
+	out := make([]string, len(f.fields))
+	for i, fi := range f.fields {
+		out[i] = path.Join(f.prefix, fi.secretName)
+	}
+	return out
+}
+
+// Apply fetches and applies the secret values required by f to the
+// corresponding fields of the input struct. Each secret must either be known
+// to s at initialization, or s must be configured to allow lookups.
+// Apply will attempt to process all tagged fields before reporting an error.
+//
+// Note: When applying secrets to struct fields from an existing Store, the
+// AllowLookup option of the Store must be enabled, or else Apply will report
+// an error for any field that refers to a secret not already available.
+func (f *Fields) Apply(s *Store) error {
+	var errs []error
+	for _, fi := range f.fields {
+		fullName := path.Join(f.prefix, fi.secretName)
+		if err := fi.apply(s, fullName); err != nil {
+			errs = append(errs, fmt.Errorf("apply %q to field %q: %w", fullName, fi.fieldName, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// fieldInfo records information about a tagged field.
+type fieldInfo struct {
+	fieldName  string        // name in the type (for diagnostics)
+	secretName string        // name in the field tag (without prefix)
+	value      reflect.Value // pointer to field
+	isJSON     bool          // if true, secret must be JSON encoded
+	vtype      reflect.Type  // type of field pointed to by value
+}
+
+// apply sets the target of fi.value to the secret named. It reports an error
+// if the requested secret could not be fetched from the store.
+//
+// If f.isJSON is true, the data are unmarshaled as JSON.
+// Otherwise, the data are converted to the target type and copied.
+func (f fieldInfo) apply(s *Store, fullName string) error {
+	if f.isJSON {
+		v, err := s.LookupSecret(fullName)
+		if err != nil {
+			return err
+		}
+		return json.Unmarshal(v.Get(), f.value.Interface())
+	}
+
+	if f.vtype == watcherType {
+		w, err := s.LookupWatcher(fullName)
+		if err != nil {
+			return err
+		}
+		f.value.Elem().Set(reflect.ValueOf(w))
+		return nil
+	}
+
+	v, err := s.LookupSecret(fullName)
+	if err != nil {
+		return err
+	}
+	switch f.vtype {
+	case bytesType:
+		f.value.Elem().Set(reflect.ValueOf(v.Get()))
+	case stringType:
+		f.value.Elem().Set(reflect.ValueOf(string(v.Get())))
+	case secretType:
+		f.value.Elem().Set(reflect.ValueOf(v))
+	default:
+		return fmt.Errorf("unexpected field type %v", f.vtype)
+	}
+	return nil
+}
+
+var (
+	bytesType   = reflect.TypeOf([]byte(nil))
+	secretType  = reflect.TypeOf(Secret(nil))
+	stringType  = reflect.TypeOf(string(""))
+	watcherType = reflect.TypeOf(Watcher{})
+)
+
+// parseFields constructs a field list for obj, which must be a pointer to a
+// struct. The result contains one entry for each field of *obj having a
+// "setec" struct tag, giving the base name of the secret to use for that
+// field.
+func parseFields(obj any) ([]fieldInfo, error) {
+	v := reflect.ValueOf(obj)
+	vt := v.Type()
+	if vt.Kind() != reflect.Pointer || vt.Elem().Kind() != reflect.Struct {
+		return nil, errors.New("value is not a pointer to a struct")
+	}
+	vt = vt.Elem()
+	var out []fieldInfo
+	for _, ft := range reflect.VisibleFields(vt) {
+		tag, ok := ft.Tag.Lookup("setec")
+		if !ok {
+			continue // not a relevant field
+		}
+		parts := strings.Split(tag, ",")
+		if parts[0] == "" {
+			return nil, fmt.Errorf("empty secret name for tagged field %q", ft.Name)
+		}
+		fi := fieldInfo{
+			fieldName:  ft.Name,
+			secretName: parts[0],
+			value:      v.Elem().FieldByIndex(ft.Index).Addr(),
+			isJSON:     slices.Contains(parts[1:], "json"),
+			vtype:      ft.Type,
+		}
+		if !fi.isJSON {
+			switch ft.Type {
+			case bytesType, stringType, secretType, watcherType:
+				// OK, these are supported
+			default:
+				return nil, fmt.Errorf("unsupported type %v for tagged field %q", ft.Type, ft.Name)
+			}
+		}
+		out = append(out, fi)
+	}
+	return out, nil
+}

--- a/client/setec/fields_test.go
+++ b/client/setec/fields_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package setec_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/tailscale/setec/client/setec"
+	"github.com/tailscale/setec/setectest"
+	"tailscale.com/types/logger"
+)
+
+type testObj struct {
+	X string `json:"x"`
+	Y bool   `json:"y"`
+}
+
+func TestFields(t *testing.T) {
+	// Populate a secret service with placeholder values for tagged secrets.
+	secrets := map[string]string{
+		"apple":  "1",
+		"pear":   "2",
+		"plum":   "3",
+		"cherry": "4",
+
+		// A JSON-encoded value compatible with testObj.
+		"object-value": `{"x":"hello","y":true}`,
+
+		// A JSON-encoded value compatible with an int64.
+		"int-value": `12345`,
+	}
+	db := setectest.NewDB(t, nil)
+	for name, val := range secrets {
+		db.MustPut(db.Superuser, "test/"+name, val)
+	}
+
+	ss := setectest.NewServer(t, db, nil)
+	hs := httptest.NewServer(ss.Mux)
+	defer hs.Close()
+
+	// Verify that if we parse secrets with a store enabled, we correctly plumb
+	// the values from the service into the tagged fields.
+	type testTarget struct {
+		A string        `setec:"apple"`
+		P []byte        `setec:"pear"`
+		L setec.Secret  `setec:"plum"`
+		C setec.Watcher `setec:"cherry"`
+		X string        // untagged, not affected
+		J testObj       `setec:"object-value,json"`
+		Z int           `setec:"int-value,json"`
+	}
+	var obj testTarget
+
+	f, err := setec.ParseFields(&obj, "test")
+	if err != nil {
+		t.Fatalf("ParseFields: unexpected error: %v", err)
+	}
+
+	st, err := setec.NewStore(context.Background(), setec.StoreConfig{
+		Client: setec.Client{Server: hs.URL, DoHTTP: hs.Client().Do},
+		Structs: []setec.Struct{
+			{Value: &obj, Prefix: "test"},
+		},
+		Logf: logger.Discard,
+	})
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	defer st.Close()
+
+	// Check that secret names respect prefixing.
+	if diff := cmp.Diff(f.Secrets(), []string{
+		"test/apple", "test/pear", "test/plum", "test/cherry",
+		"test/object-value", "test/int-value",
+	}); diff != "" {
+		t.Errorf("Prefixed secret names (-got, +want):\n%s", diff)
+	}
+
+	// Check that we can apply values.
+	if err := f.Apply(st); err != nil {
+		t.Errorf("Apply failed; %v", err)
+	}
+
+	// Don't try to compare complex plumbing; see below.
+	opt := cmpopts.IgnoreFields(testTarget{}, "L", "C")
+	if diff := cmp.Diff(obj, testTarget{
+		A: secrets["apple"],
+		P: []byte(secrets["pear"]),
+		J: testObj{X: "hello", Y: true},
+		Z: 12345,
+	}, opt); diff != "" {
+		t.Errorf("Populated value (-got, +want):\n%s", diff)
+	}
+
+	// Check the handle-plumbed fields.
+	if got, want := string(obj.L.Get()), secrets["plum"]; got != want {
+		t.Errorf("Secret field: got %q, want %q", got, want)
+	}
+	if got, want := string(obj.C.Get()), secrets["cherry"]; got != want {
+		t.Errorf("Secret field: got %q, want %q", got, want)
+	}
+}
+
+func TestParseErrors(t *testing.T) {
+	checkFail := func(input any, wantErr string) func(t *testing.T) {
+		return func(t *testing.T) {
+			f, err := setec.ParseFields(input, "")
+			if err == nil {
+				t.Fatalf("Parse: got %v, want error", f)
+			} else if !strings.Contains(err.Error(), wantErr) {
+				t.Fatalf("Parse: got error %v, want %q", err, wantErr)
+			}
+		}
+	}
+	t.Run("NonPointer", checkFail(struct{ X string }{}, "not a pointer"))
+	t.Run("NonStruct", checkFail(new(string), "not a pointer to a struct"))
+	t.Run("NoTaggedFields", checkFail(&struct{ X string }{}, "no setec-tagged fields"))
+	t.Run("InvalidType", checkFail(&struct {
+		X float64 `setec:"x"` // N.B. not marked with JSON
+	}{}, "unsupported type"))
+}

--- a/client/setec/store.go
+++ b/client/setec/store.go
@@ -73,15 +73,26 @@ type StoreConfig struct {
 	// The service URL must be non-empty.
 	Client Client
 
-	// Secrets are the names of the secrets this Store should retrieve. Unless
-	// AllowLookup is true, only secrets named here can be read out of the store
-	// and an error is reported if no secrets are listed here.
+	// Secrets are the names of secrets this Store should retrieve.
+	//
+	// Unless AllowLookup is true, only secrets named here or in the Structs
+	// field can be read out of the store and an error is reported if no secrets
+	// are listed.
 	Secrets []string
+
+	// Structs are optional struct values with tagged fields that should be
+	// populated with secrets from the store at initialization time.
+	//
+	// Unless AllowLookup is true, only secrets named here or in the Secrets
+	// field can be read out of the store and an error is reported if no secrets
+	// are listed.
+	Structs []Struct
 
 	// AllowLookup instructs the store to allow the caller to look up secrets
 	// not known to the store at the time of construction. If false, only
-	// secrets pre-declared in the Secrets slice can be fetched, and the Lookup
-	// and LookupWatcher methods will report an error for all un-listed secrets.
+	// secrets pre-declared in the Secrets and Structs slices can be fetched,
+	// and the Lookup and LookupWatcher methods will report an error for all
+	// un-listed secrets.
 	AllowLookup bool
 
 	// Cache, if non-nil, is a cache that persists secrets locally.
@@ -161,7 +172,12 @@ func (c StoreConfig) timeNow() func() time.Time {
 func NewStore(ctx context.Context, cfg StoreConfig) (*Store, error) {
 	if cfg.Client.Server == "" {
 		return nil, errors.New("no service URL is set")
-	} else if len(cfg.Secrets) == 0 && !cfg.AllowLookup {
+	}
+
+	secrets, structs, err := cfg.secretNames()
+	if err != nil {
+		return nil, err
+	} else if len(secrets) == 0 && !cfg.AllowLookup {
 		return nil, errors.New("no secrets are listed")
 	}
 
@@ -203,7 +219,7 @@ func NewStore(ctx context.Context, cfg StoreConfig) (*Store, error) {
 	// after completing initialization, so that we will have a cache of the
 	// latest data in case we restart before the next poll.
 	var wantFlush bool
-	for _, name := range cfg.Secrets {
+	for _, name := range secrets {
 		if _, ok := s.active.m[name]; ok {
 			s.active.m[name].Declared = true
 		} else {
@@ -219,6 +235,13 @@ func NewStore(ctx context.Context, cfg StoreConfig) (*Store, error) {
 	if wantFlush {
 		if err := s.flushCacheLocked(); err != nil {
 			s.logf("WARNING: error flushing cache: %v", err)
+		}
+	}
+
+	// Plumb secrets in to struct fields, if necessary.
+	for _, fi := range structs {
+		if err := fi.Apply(s); err != nil {
+			return nil, fmt.Errorf("apply secrets to struct: %w", err)
 		}
 	}
 
@@ -692,4 +715,34 @@ func (c *cachedSecret) lastAccessTime() time.Time {
 type secretState struct {
 	expired bool
 	version api.SecretVersion
+}
+
+// Struct describes a struct value with tagged fields that should be populated
+// with secrets from a Store.
+type Struct struct {
+	// Value must be a non-nil pointer to a value of struct type, having at
+	// least one field tagged with a "setec" field tag.
+	// See Fields for a description of the tag format.
+	Value any
+
+	// Prefix is an optional prefix that should be prepended to each secret
+	// described by a tag in Value to obtain the secret name to look up.
+	Prefix string
+}
+
+func (c StoreConfig) secretNames() ([]string, []*Fields, error) {
+	sec := c.Secrets
+	var svs []*Fields
+	for _, s := range c.Structs {
+		fs, err := ParseFields(s.Value, s.Prefix)
+		if err != nil {
+			return nil, nil, fmt.Errorf("parse struct fields: %w", err)
+		}
+
+		// We don't need to deduplicate here, the constructor merges all the
+		// names into a map.
+		sec = append(sec, fs.Secrets()...)
+		svs = append(svs, fs)
+	}
+	return sec, svs, nil
 }


### PR DESCRIPTION
Given a pointer to a struct with specially-tagged fields, use reflection to
locate these fields and plumb secrets from a setec.Store into them.
