### PR TITLE
cmd/setec: do not prompt for secret values when stdin is a pipe

### DIFF
--- a/cmd/setec/setec.go
+++ b/cmd/setec/setec.go
@@ -96,8 +96,9 @@ With --if-changed, return the active value only if it differs from --version.`,
 				Usage: "<secret-name>",
 				Help: `Put a new value for the specified secret.
 
-With --from-file, the new value is read from the specified file; otherwise
-the user is prompted for a new value and confirmation at the terminal.`,
+With --from-file, the new value is read from the specified file; otherwise if
+stdin is connected to a pipe, its contents are fully read to obtain the new
+value. Otherwise, the user is prompted for a new value and confirmation.`,
 
 				SetFlags: command.Flags(flax.MustBind, &putArgs),
 				Run:      command.Adapt(runPut),


### PR DESCRIPTION
I debated whether to make an additional flag to specifically request this
behaviour, but since we already sniff the terminal for output I thought I'd
start with this.

Curiously, I noticed we also trim space off a file input, which is kinda OK if
we know the file is text, but could break binary input. We might want a flag to
override that in one direction or other too.
