### PR TITLE
cmd/setec: don't trim whitespace from binary file input

### DIFF
--- a/cmd/setec/setec.go
+++ b/cmd/setec/setec.go
@@ -23,6 +23,7 @@ import (
 	"syscall"
 	"text/tabwriter"
 	"time"
+	"unicode/utf8"
 
 	"github.com/creachadair/command"
 	"github.com/creachadair/flax"
@@ -379,7 +380,11 @@ func runPut(env *command.Env, name string) error {
 		if err != nil {
 			return err
 		}
-		value = bytes.TrimSpace(value)
+		// If the value we read is all valid UTF-8, trim leading and trailing
+		// whitespace.  If not, the value is binary and we shouldn't do that.
+		if utf8.Valid(value) {
+			value = bytes.TrimSpace(value)
+		}
 	} else if term.IsTerminal(int(os.Stdin.Fd())) {
 		// Standard input is connected to a terminal; prompt the human to type or
 		// paste the value and require confirmation.


### PR DESCRIPTION
When reading secret data from a file, only trim leading and trailing whitespace
if the content is valid UTF-8 text, so that we do not accidentally mangle
binary values with whitespace-looking bytes at the head or tail. For example,
in protocol buffer messages, LF (10) is a common tag byte.
