### PR TITLE
cmd/setec: add a flag to allow "put" of an empty secret value

### DIFF
--- a/cmd/setec/setec.go
+++ b/cmd/setec/setec.go
@@ -386,6 +386,9 @@ func runPut(env *command.Env, name string) error {
 		if utf8.Valid(value) {
 			value = bytes.TrimSpace(value)
 		}
+		if len(value) == 0 && !putArgs.EmptyOK {
+			return errors.New("empty secret value")
+		}
 	} else if term.IsTerminal(int(os.Stdin.Fd())) {
 		// Standard input is connected to a terminal; prompt the human to type or
 		// paste the value and require confirmation.

--- a/cmd/setec/setec.go
+++ b/cmd/setec/setec.go
@@ -363,7 +363,8 @@ func runGet(env *command.Env, name string) error {
 }
 
 var putArgs struct {
-	File string `flag:"from-file,Read secret value from this file instead of stdin"`
+	File    string `flag:"from-file,Read secret value from this file instead of stdin"`
+	EmptyOK bool   `flag:"empty-ok,Allow an empty secret value"`
 }
 
 func runPut(env *command.Env, name string) error {
@@ -396,7 +397,7 @@ func runPut(env *command.Env, name string) error {
 		if err != nil {
 			return err
 		}
-		if len(value) == 0 {
+		if len(value) == 0 && !putArgs.EmptyOK {
 			return errors.New("no secret provided, aborting")
 		}
 		io.WriteString(os.Stdout, "Confirm secret: ")
@@ -414,7 +415,7 @@ func runPut(env *command.Env, name string) error {
 		value, err = io.ReadAll(os.Stdin)
 		if err != nil {
 			return fmt.Errorf("read from stdin: %w", err)
-		} else if len(value) == 0 {
+		} else if len(value) == 0 && !putArgs.EmptyOK {
 			return errors.New("empty secret value")
 		}
 		fmt.Fprintf(env, "Read %d bytes from stdin\n", len(value))


### PR DESCRIPTION
Ordinarily an empty secret value is an error, since that is usually not
intended.  In some cases it may be needed, however, e.g., if a program runs in
multiple environments and some of its secrets are not relevant to all of them.

With the --empty-ok flag, "put" will now permit an empty secret.
