### PR TITLE
Add a tag to accept missing struct field secrets

### DIFF
--- a/client/setec/fields_test.go
+++ b/client/setec/fields_test.go
@@ -160,7 +160,7 @@ func TestMissingFields(t *testing.T) {
 		t.Fatalf("ParseFields: unexpected error: %v", err)
 	}
 
-	if err := f.Apply(st); err != nil {
+	if err := f.Apply(context.Background(), st); err != nil {
 		t.Errorf("Apply failed: %v", err)
 	}
 	if tf.Z != 12345 {


### PR DESCRIPTION
Ordinarily if the requested secret for a tagged struct field is missing or
inacessible, application of secrets to that struct fails.

Now, fields tagged "allowmissing" will default missing or inaccesible secrets
to a static empty string.
