### PR TITLE
client/setec: document ownership of Secret values and add GetString

### DIFF
--- a/client/setec/store.go
+++ b/client/setec/store.go
@@ -413,11 +413,19 @@ func (s *Store) LookupWatcher(name string) (Watcher, error) {
 // A Secret is a function that fetches the current active value of a secret.
 // The caller should not cache the value returned; the function does not block
 // and will always report a valid (if possibly stale) result.
+//
+// The Secret retains ownership of the bytes returned, but the store will never
+// modify the contents of the secret, so it is safe to share the slice without
+// copying as long as the caller does not modify them.
 type Secret func() []byte
 
 // Get returns the current active value of the secret.  It is a legibility
 // alias for calling the function.
 func (s Secret) Get() []byte { return s() }
+
+// GetString returns a copy of the current active value of the secret as a
+// string.
+func (s Secret) GetString() string { return string(s()) }
 
 // StaticSecret returns a Secret that vends a static string value.
 // This is useful as a placeholder for development, migration, and testing.

--- a/client/setec/store_test.go
+++ b/client/setec/store_test.go
@@ -4,6 +4,7 @@
 package setec_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -24,7 +25,10 @@ func checkSecretValue(t *testing.T, st *setec.Store, name, want string) setec.Se
 	if f == nil {
 		t.Fatalf("Secret %q not found", name)
 	}
-	if got := string(f.Get()); got != want {
+	if got := f.Get(); !bytes.Equal(got, []byte(want)) {
+		t.Fatalf("Secret %q: got %q, want %q", name, got, want)
+	}
+	if got := f.GetString(); got != want {
 		t.Fatalf("Secret %q: got %q, want %q", name, got, want)
 	}
 	return f
@@ -159,7 +163,7 @@ func TestCachedStore(t *testing.T) {
 	// we see it without having to update explicitly.
 	pollTicker.Poll()
 
-	if got, want := string(alpha.Get()), "bazquux"; got != want {
+	if got, want := alpha.GetString(), "bazquux"; got != want {
 		t.Fatalf("Lookup alpha: got %q, want %q", got, want)
 	}
 
@@ -182,7 +186,7 @@ func TestCachedStore(t *testing.T) {
 		}
 		check("counter_poll_initiated", "1")
 		check("counter_poll_errors", "0")
-		check("counter_secret_fetch", "2")
+		check("counter_secret_fetch", "3")
 	})
 }
 


### PR DESCRIPTION
Explicitly note that the Secret retains ownership of the bytes it returns, and
document that read-only sharing of the slice is safe.

In addition, add a GetString method to Secret that sugars copying the bytes
into a new string. The caller could also just do this, but having the method
make the intent perhaps more clear.
