### PR TITLE
client/setec: single-flight dynamic lookups

### DIFF
--- a/client/setec/store.go
+++ b/client/setec/store.go
@@ -382,9 +382,9 @@ func (s *Store) lookupSecretInternal(ctx context.Context, name string) (Secret, 
 		if err == nil {
 			return v.(Secret), nil
 		} else if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
-			// If this was our context, we'll fall out on the next loop test.
 			return nil, err
 		}
+		// Cancelled or deadline exceeed.  If it was us, we'll fall off the loop.
 	}
 	return nil, ctx.Err()
 }


### PR DESCRIPTION
From a discussion with @bradfitz.  We already have single-flighting in the
store for polls anyway, so this is a straightforward extension.

For callers like scertec, it is very likely that a dynamic lookup may have a
large number of goroutines that all want the same secrets near a (re)start.
Single-flight the lookup so they don't all pound the secrets service and then
race on poking the value into the store.
