### PR TITLE
client/setec: allow struct fields that implement UnmarshalBinary

### DIFF
--- a/client/setec/fields.go
+++ b/client/setec/fields.go
@@ -146,7 +146,7 @@ type fieldInfo struct {
 	fieldName  string             // name in the type (for diagnostics)
 	secretName string             // name in the field tag (without prefix)
 	value      reflect.Value      // pointer to field
-	setText    func([]byte) error // if non-nil, call to unmarshal the value
+	unmarshal  func([]byte) error // if non-nil, call to unmarshal the value
 	isJSON     bool               // if true, secret must be JSON encoded
 	vtype      reflect.Type       // type of field pointed to by value
 }
@@ -178,8 +178,8 @@ func (f fieldInfo) apply(ctx context.Context, s *Store, fullName string) error {
 	if err != nil {
 		return err
 	}
-	if f.setText != nil {
-		return f.setText(v.Get())
+	if f.unmarshal != nil {
+		return f.unmarshal(v.Get())
 	}
 	switch f.vtype {
 	case bytesType:
@@ -232,7 +232,7 @@ func parseFields(obj any) ([]fieldInfo, error) {
 		}
 		if !fi.isJSON {
 			if u := checkUnmarshal(fi.value); u != nil {
-				fi.setText = u
+				fi.unmarshal = u
 			} else {
 				switch ft.Type {
 				case bytesType, stringType, secretType, watcherType:

--- a/client/setec/fields.go
+++ b/client/setec/fields.go
@@ -5,6 +5,7 @@ package setec
 
 import (
 	"context"
+	"encoding"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -76,9 +77,16 @@ func ParseFields(v any, namePrefix string) (*Fields, error) {
 // The Fields type can handle struct fields of the following types:
 //
 //   - A field of type []byte receives a copy of the secret value.
+//
 //   - A field of type string receives a copy of the secret as a string.
+//
 //   - A field of type [setec.Secret] is populated with a handle to the secret.
+//
 //   - A field of type [setec.Watcher] is populated with a watcher for the secret.
+//
+//   - A field whose (pointer) type implements the [encoding.BinaryUnmarshaler]
+//     interface has its UnmarshalBinary method called with the secret value.
+//     This may be used to handle structured data, or to add validation.
 //
 // In addition, a field may have any type that supports JSON encoding, provided
 // the secret value is also encoded as JSON, if its tag includes the optional
@@ -135,11 +143,12 @@ func (f *Fields) Apply(ctx context.Context, s *Store) error {
 
 // fieldInfo records information about a tagged field.
 type fieldInfo struct {
-	fieldName  string        // name in the type (for diagnostics)
-	secretName string        // name in the field tag (without prefix)
-	value      reflect.Value // pointer to field
-	isJSON     bool          // if true, secret must be JSON encoded
-	vtype      reflect.Type  // type of field pointed to by value
+	fieldName  string             // name in the type (for diagnostics)
+	secretName string             // name in the field tag (without prefix)
+	value      reflect.Value      // pointer to field
+	setText    func([]byte) error // if non-nil, call to unmarshal the value
+	isJSON     bool               // if true, secret must be JSON encoded
+	vtype      reflect.Type       // type of field pointed to by value
 }
 
 // apply sets the target of fi.value to the secret named. It reports an error
@@ -169,6 +178,9 @@ func (f fieldInfo) apply(ctx context.Context, s *Store, fullName string) error {
 	if err != nil {
 		return err
 	}
+	if f.setText != nil {
+		return f.setText(v.Get())
+	}
 	switch f.vtype {
 	case bytesType:
 		f.value.Elem().Set(reflect.ValueOf(v.Get()))
@@ -187,6 +199,7 @@ var (
 	secretType  = reflect.TypeOf(Secret(nil))
 	stringType  = reflect.TypeOf(string(""))
 	watcherType = reflect.TypeOf(Watcher{})
+	binaryType  = reflect.TypeOf((*encoding.BinaryUnmarshaler)(nil)).Elem()
 )
 
 // parseFields constructs a field list for obj, which must be a pointer to a
@@ -218,14 +231,37 @@ func parseFields(obj any) ([]fieldInfo, error) {
 			vtype:      ft.Type,
 		}
 		if !fi.isJSON {
-			switch ft.Type {
-			case bytesType, stringType, secretType, watcherType:
-				// OK, these are supported
-			default:
-				return nil, fmt.Errorf("unsupported type %v for tagged field %q", ft.Type, ft.Name)
+			if u := checkUnmarshal(fi.value); u != nil {
+				fi.setText = u
+			} else {
+				switch ft.Type {
+				case bytesType, stringType, secretType, watcherType:
+					// OK, these types are supported.
+				default:
+					return nil, fmt.Errorf("unsupported type %v for tagged field %q", ft.Type, ft.Name)
+				}
 			}
 		}
 		out = append(out, fi)
 	}
 	return out, nil
+}
+
+// checkUnmarshal checks whether v implements an unmarshaler type, and if so
+// returns a function to unmarshal a secret value into the target.  Otherwise
+// it returns nil, indicating the field does not have its own unmarshaler.
+func checkUnmarshal(v reflect.Value) func([]byte) error {
+	// The pointer to the field value implements the unmarshaler.
+	if v.Type().Implements(binaryType) {
+		return v.Interface().(encoding.BinaryUnmarshaler).UnmarshalBinary
+	}
+	// The field value is itself a pointer that implements the unmarshaler.
+	if pt := v.Elem().Type(); pt.Implements(binaryType) {
+		// If the field value is nil, allocate a value to unmarshal into.
+		if v.Elem().IsNil() {
+			v.Elem().Set(reflect.New(pt.Elem()))
+		}
+		return v.Elem().Interface().(encoding.BinaryUnmarshaler).UnmarshalBinary
+	}
+	return nil // not applicable
 }


### PR DESCRIPTION
In addition to the existing supported types, allow fields whose pointer
implements the encoding.BinaryUnmarshaler interface to receive secret values
via their UnmarshalBinary method.

This may be used to handle structured binary values, or to perform basic
validation on the secret value (e.g., the implementation can report an error if
the value is invalid, but otherwise copy it).
