### PR TITLE
client/setec: panic for undeclared secrets when lookups are disabled

### DIFF
--- a/client/setec/store.go
+++ b/client/setec/store.go
@@ -310,7 +310,7 @@ func (s *Store) Refresh(ctx context.Context) error {
 func (s *Store) Secret(name string) Secret {
 	sec := s.secretOrNil(name)
 	if sec == nil && !s.allowLookup {
-		panic(fmt.Sprintf("secret %q not found with lookup disabled", name))
+		panic(fmt.Sprintf("secret %q not found in StoreConfig with lookup disabled", name))
 	}
 	return sec
 }
@@ -426,7 +426,7 @@ func (s *Store) Watcher(name string) Watcher {
 		if s.allowLookup {
 			return Watcher{}
 		}
-		panic(fmt.Sprintf("secret %q not found with lookup disabled", name))
+		panic(fmt.Sprintf("secret %q not found in StoreConfig with lookup disabled", name))
 	}
 	w := Watcher{ready: make(chan struct{}, 1), secret: secret}
 	s.active.w[name] = append(s.active.w[name], w)

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.26.7
 	github.com/creachadair/command v0.1.5
 	github.com/creachadair/flax v0.0.0-20231211041532-4d51c109e3c1
+	github.com/creachadair/mds v0.12.2
 	github.com/google/go-cmp v0.6.0
 	github.com/tink-crypto/tink-go-awskms v0.0.0-20230616072154-ba4f9f22c3e9
 	github.com/tink-crypto/tink-go/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/creachadair/command v0.1.5 h1:7Nl4qcV7OasGsKCnAHIGlzBW5uNdwzGZLbc3OM8
 github.com/creachadair/command v0.1.5/go.mod h1:YKwUE49nAi8qxLl8jCQ0GMPvwdxmIBkJW3LqxgZ7ljk=
 github.com/creachadair/flax v0.0.0-20231211041532-4d51c109e3c1 h1:qT1aIcWGe9TZqjIkjwsLMZzziZN2e3QPpb0DVSZCrlM=
 github.com/creachadair/flax v0.0.0-20231211041532-4d51c109e3c1/go.mod h1:2vVCsqiB+GpV/qBKCQ0lKRrJhlKUPdI83SnaFKwJyNo=
-github.com/creachadair/mds v0.3.0 h1:uKbCKVtd3iOKVv3uviOm13fFNfe9qoCXJh1Vo7y3Kr0=
-github.com/creachadair/mds v0.3.0/go.mod h1:4vrFYUzTXMJpMBU+OA292I6IUxKWCCfZkgXg+/kBZMo=
+github.com/creachadair/mds v0.12.2 h1:CyJUaInwFnLUcMgJjVMLG3qYDziSbaY1KXBCvsLrTwQ=
+github.com/creachadair/mds v0.12.2/go.mod h1:4vrFYUzTXMJpMBU+OA292I6IUxKWCCfZkgXg+/kBZMo=
 github.com/creack/pty v1.1.21 h1:1/QdRyBaHHJP61QkWMXlOIBfsgdDeeKfK8SYVUWJKf0=
 github.com/creack/pty v1.1.21/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
We stumbled on a sharp corner, viz., that if you forget to declare a secret to
the Store, the store will start up just fine, but code that refers to that name
will return a nil Secret and panic later at the point of use.

Since a program that does this is already statically incorrect, generate the
panic (with a more helpful diagnostic) immediately when the secret is accessed
rather than letting it show up as a random nil indirection later.

When lookups are enabled, however, retain the current behaviour of reporting a
nil secret or empty Watcher: By enabling lookups the caller has announced that
it is prepared to deal with dynamic conditions, and can be expected to do the
needful.

Add an IsValid method to a Watcher to make this easier to check.
