### PR TITLE
WIP: Adding multi-valued secrets ("keyrings") to setec

### DIFF
--- a/client/setec/keyring.go
+++ b/client/setec/keyring.go
@@ -1,0 +1,62 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package setec
+
+import (
+	"sync"
+
+	"github.com/tailscale/setec/types/api"
+)
+
+/*
+   TODO:
+   - Cache needs to be able to hold multiple values.
+   - Keep track of single- vs keyring-valued secrets.
+   - Update polling logic to use GetAll for keyrings.
+   - Add settings.
+*/
+
+// A Keyring represents a a collection of one or more available versions of a
+// named secret.
+type Keyring struct {
+	name string
+
+	mu     sync.Mutex
+	active int                // index into values
+	values []*api.SecretValue // in increasing order by version
+}
+
+// Get returns the key at index i of the keyring. Index 0 always refers to the
+// current active version, and further indexes refer to other versions in order
+// from newest to oldest.
+//
+// If i >= r.Len(), Get returns nil. If i < 0, Get panics.
+//
+// The Keyring retains ownership of the bytes returned, but the store will
+// never modify the contents of the secret, so it is safe to share the slice
+// without copying as long as the caller does not modify them.
+func (r *Keyring) Get(i int) []byte {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	switch {
+	case i < 0:
+		panic("index is negative")
+	case i < len(r.values):
+		return r.values[i].Value
+	default:
+		return nil
+	}
+}
+
+// GetString returns a copy of the key at index i of the keyring as a string.
+// If i >= r.Len(), GetString returns "". Otherwise, GetString behaves as Get.
+func (r *Keyring) GetString(i int) string { return string(r.Get(i)) }
+
+// Len reports the number of keys stored in r. The length is always positive,
+// counting the active version.
+func (r *Keyring) Len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.values)
+}

--- a/db/kv.go
+++ b/db/kv.go
@@ -304,6 +304,22 @@ func (kv *kv) get(name string) (*api.SecretValue, error) {
 	}, nil
 }
 
+// getAll returns all the versions of a secret, and the active version number.
+func (kv *kv) getAll(name string) (api.SecretVersion, []*api.SecretValue, error) {
+	secret := kv.secrets[name]
+	if secret == nil {
+		return 0, nil, ErrNotFound
+	}
+	all := make([]*api.SecretValue, 0, len(secret.Versions))
+	for v, bs := range secret.Versions {
+		all = append(all, &api.SecretValue{
+			Value:   []byte(bs),
+			Version: v,
+		})
+	}
+	return secret.ActiveVersion, all, nil
+}
+
 // getVersion returns a secret's value at a specific version.
 func (kv *kv) getVersion(name string, version api.SecretVersion) (*api.SecretValue, error) {
 	secret := kv.secrets[name]

--- a/server/server.go
+++ b/server/server.go
@@ -15,6 +15,7 @@ import (
 	"log"
 	"net/http"
 	"net/netip"
+	"slices"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -131,6 +132,7 @@ func New(ctx context.Context, cfg Config) (*Server, error) {
 	cfg.Mux.Handle("/static/", http.FileServer(http.FS(staticFiles)))
 	cfg.Mux.HandleFunc("/api/list", ret.list)
 	cfg.Mux.HandleFunc("/api/get", ret.get)
+	cfg.Mux.HandleFunc("/api/get-all", ret.getAll)
 	cfg.Mux.HandleFunc("/api/info", ret.info)
 	cfg.Mux.HandleFunc("/api/put", ret.put)
 	cfg.Mux.HandleFunc("/api/activate", ret.activate)
@@ -218,6 +220,21 @@ func (s *Server) get(w http.ResponseWriter, r *http.Request) {
 		}
 		// Case 3: Unconditional fetch of active version.
 		return s.db.Get(id, req.Name)
+	})
+}
+
+func (s *Server) getAll(w http.ResponseWriter, r *http.Request) {
+	serveJSON(s, w, r, func(req api.GetAllRequest, id db.Caller) (*api.GetAllResponse, error) {
+		filtered, err := s.db.GetAllFiltered(id, req.Name, req.SkipVersions)
+		if err != nil {
+			return nil, err
+		}
+		slices.Sort(filtered.Versions)
+		return &api.GetAllResponse{
+			Active:   filtered.Active,
+			Versions: filtered.Versions,
+			Values:   filtered.Values,
+		}, nil
 	})
 }
 

--- a/types/api/api.go
+++ b/types/api/api.go
@@ -82,6 +82,31 @@ type GetRequest struct {
 	UpdateIfChanged bool
 }
 
+// GetAllRequest is a request to get all the available versions of a secret.
+type GetAllRequest struct {
+	// Name is the name of the secret to fetch.
+	Name string
+
+	// SkipVersions, if non-empty, lists versions the caller already has and
+	// does not need to have returned. The server will not return any of the
+	// versions listed here.
+	SkipVersions []SecretVersion
+}
+
+// GetAllResponse is a response from a successful GetAllRequest.
+type GetAllResponse struct {
+	// Active is the current active version of the secret. It is set even if no
+	// secret values are returned.
+	Active SecretVersion
+
+	// Versions contains all the known versions of the secret.
+	Versions []SecretVersion
+
+	// Values contains all the known values of the secret, but omitting any
+	// versions that were listed in the SkipVersions field of the request.
+	Values []*SecretValue
+}
+
 // InfoRequest is a request for secret metadata.
 type InfoRequest struct {
 	// Name is the name of the secret whose metadata to return.


### PR DESCRIPTION
This is not ready for use yet, but I wanted to put the outlines up for us to
talk about. The server API is all implemented and works fine, the integration
with the Store type is not yet done.

- **types: add GetAllRequest and GetAllResponse**
- **db: add a getAll method to kv and GetAllFiltered to DB**
- **server: add /api/get-all**
- **client/setec: sketch of keyring**
