### PR TITLE
client: return empty secrets from nil Secret and zero Watcher values

### DIFF
--- a/client/setec/store.go
+++ b/client/setec/store.go
@@ -475,12 +475,22 @@ func (s *Store) LookupWatcher(ctx context.Context, name string) (Watcher, error)
 type Secret func() []byte
 
 // Get returns the current active value of the secret.  It is a legibility
-// alias for calling the function.
-func (s Secret) Get() []byte { return s() }
+// alias for calling the function. If s == nil, Get returns nil.
+func (s Secret) Get() []byte {
+	if s == nil {
+		return nil
+	}
+	return s()
+}
 
 // GetString returns a copy of the current active value of the secret as a
-// string.
-func (s Secret) GetString() string { return string(s()) }
+// string. If s == nil, GetString returns "".
+func (s Secret) GetString() string {
+	if s == nil {
+		return ""
+	}
+	return string(s())
+}
 
 // StaticSecret returns a Secret that vends a static string value.
 // This is useful as a placeholder for development, migration, and testing.
@@ -765,6 +775,7 @@ type Watcher struct {
 }
 
 // Get returns the current active value of the secret.
+// A zero-valued Watcher returns nil.
 func (w Watcher) Get() []byte { return w.secret.Get() }
 
 // Ready returns a channel that delivers a value when the current active

--- a/client/setec/store_test.go
+++ b/client/setec/store_test.go
@@ -623,6 +623,21 @@ func TestNewFileCache(t *testing.T) {
 	})
 }
 
+func TestNilSecret(t *testing.T) {
+	var s setec.Secret
+	var w setec.Watcher
+
+	if got := s.Get(); got != nil {
+		t.Errorf("(nil).Get: got %v, want nil", got)
+	}
+	if got := s.GetString(); got != "" {
+		t.Errorf(`(nil).GetString: got %q, want ""`, got)
+	}
+	if got := w.Get(); got != nil {
+		t.Errorf("(zero).Get: got %v, want nil", got)
+	}
+}
+
 type badCache struct{}
 
 func (badCache) Write([]byte) error    { return errors.New("write failed") }


### PR DESCRIPTION
As a convenience for the caller, rather than having to check both for nil and
for an empty value, make the Get and GetString methods return appropriate empty
values (nil for []byte, "" for string) on a nil/zero receiver.
