### PR TITLE
client: add a StaticWatcher utility constructor

### DIFF
--- a/client/setec/static.go
+++ b/client/setec/static.go
@@ -1,0 +1,53 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package setec
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+)
+
+// StaticSecret returns a Secret that vends a static string value.
+// This is useful as a placeholder for development, migration, and testing.
+// The value reported by a static secret never changes.
+func StaticSecret(value string) Secret {
+	return func() []byte { return []byte(value) }
+}
+
+// StaticWatcher returns a Watcher that vends a static string value.
+// This is useful as a placeholder for development, migration, and testing.
+// The value reported by a static watcher never changes, and the watcher
+// channel is never ready.
+func StaticWatcher(value string) Watcher {
+	return Watcher{secret: StaticSecret(value)}
+}
+
+// StaticFile returns a Secret that vends the contents of path.  The contents
+// of the file are returned exactly as stored.
+//
+// This is useful as a placeholder for development, migration, and testing.
+// The value reported by this secret is the contents of path at the
+// time this function is called, and never changes.
+func StaticFile(path string) (Secret, error) {
+	bs, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading static secret: %w", err)
+	}
+	return func() []byte { return bs }, nil
+}
+
+// StaticTextFile returns a secret that vends the contents of path, which are
+// treated as text with leading and trailing whitespace trimmed.
+//
+// This is useful as a placeholder for development, migration, and testing.
+// The value reported by a static secret never changes.
+func StaticTextFile(path string) (Secret, error) {
+	bs, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading static secret: %w", err)
+	}
+	text := bytes.TrimSpace(bs)
+	return func() []byte { return text }, nil
+}

--- a/client/setec/store.go
+++ b/client/setec/store.go
@@ -4,7 +4,6 @@
 package setec
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -12,7 +11,6 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
-	"os"
 	"sync"
 	"time"
 
@@ -490,41 +488,6 @@ func (s Secret) GetString() string {
 		return ""
 	}
 	return string(s())
-}
-
-// StaticSecret returns a Secret that vends a static string value.
-// This is useful as a placeholder for development, migration, and testing.
-// The value reported by a static secret never changes.
-func StaticSecret(value string) Secret {
-	return func() []byte { return []byte(value) }
-}
-
-// StaticFile returns a Secret that vends the contents of path.  The contents
-// of the file are returned exactly as stored.
-//
-// This is useful as a placeholder for development, migration, and testing.
-// The value reported by this secret is the contents of path at the
-// time this function is called, and never changes.
-func StaticFile(path string) (Secret, error) {
-	bs, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("reading static secret: %w", err)
-	}
-	return func() []byte { return bs }, nil
-}
-
-// StaticTextFile returns a secret that vends the contents of path, which are
-// treated as text with leading and trailing whitespace trimmed.
-//
-// This is useful as a placeholder for development, migration, and testing.
-// The value reported by a static secret never changes.
-func StaticTextFile(path string) (Secret, error) {
-	bs, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("reading static secret: %w", err)
-	}
-	text := bytes.TrimSpace(bs)
-	return func() []byte { return text }, nil
 }
 
 // hasExpired reports whether cs is an undeclared secret whose last access time


### PR DESCRIPTION
This helps with migration of secrets that need a Watcher in production, but
which still need static values for development and testing. The resulting
Watcher never notifies an update, but is valid and vends the provided secret.

While here, pull all the static constructors out into their own file, as the
store file is getting a bit unwieldy.

Updates tailscale/corp#22445
