### PR TITLE
server,setectest: allow creating a server with a pre-made database

### DIFF
--- a/setectest/server.go
+++ b/setectest/server.go
@@ -75,8 +75,7 @@ func NewServer(t *testing.T, db *DB, opts *ServerOptions) *Server {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	s, err := server.New(ctx, server.Config{
-		DBPath:   db.Path,
-		Key:      db.Key,
+		DB:       db.Actual,
 		AuditLog: opts.auditLog(),
 		WhoIs:    opts.whoIs(),
 		Mux:      mux,


### PR DESCRIPTION
Particularly for tests, it is helpful if the database can be given to the
server at construction time, rather than read in off disk.

Add a new DB field to the server.Config. If this field is populated, it takes
precedence over the DBPath and related fields. Otherwise, the DBPath, Key, and
AuditLog fields are all required (as before) and have the same semantics.
