### PR TITLE
client: fix corner cases in secret declaration

### DIFF
--- a/client/setec/store_test.go
+++ b/client/setec/store_test.go
@@ -115,6 +115,32 @@ func TestStore(t *testing.T) {
 			t.Errorf("Lookup(bravo): got %q, want error", s.Get())
 		}
 	})
+
+	t.Run("NewStore_emptyName", func(t *testing.T) {
+		st, err := setec.NewStore(ctx, setec.StoreConfig{
+			Client:      cli,
+			Secrets:     []string{""},
+			Logf:        logger.Discard,
+			AllowLookup: true,
+		})
+		if err == nil {
+			t.Fatalf("NewStore(empty): got %+v, want error", st)
+		}
+	})
+
+	t.Run("NewStore_dupName", func(t *testing.T) {
+		// Regression: A duplicate name can poison the initialization map, so we
+		// need to deduplicate as part of collection.
+		st, err := setec.NewStore(ctx, setec.StoreConfig{
+			Client:  cli,
+			Secrets: []string{"alpha", "alpha"},
+			Logf:    logger.Discard,
+		})
+		if err != nil {
+			t.Fatalf("NewStore(dup): unexpected error: %v", err)
+		}
+		t.Logf("NewStore: got secret %q", st.Secret("alpha").GetString())
+	})
 }
 
 func TestCachedStore(t *testing.T) {


### PR DESCRIPTION
1. Don't allow an empty secret name to be declared.  While in principle this
   could be fine, it is weird and not worth supporting.

2. Deduplicate secret names before initialization. I originally thought this
   was not needed, but because of the way we merge cached results with the
   initialization step, duplicates can "poison" the initialization state.
