### PR TITLE
all: replace exp/maps and exp/slices with base packages

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -19,6 +19,7 @@ package db
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 
@@ -26,7 +27,6 @@ import (
 	"github.com/tailscale/setec/audit"
 	"github.com/tailscale/setec/types/api"
 	"github.com/tink-crypto/tink-go/v2/tink"
-	"golang.org/x/exp/slices"
 	"tailscale.com/util/multierr"
 )
 

--- a/db/kv.go
+++ b/db/kv.go
@@ -13,7 +13,6 @@ import (
 	"maps"
 	"os"
 	"slices"
-	"sort"
 
 	"github.com/tailscale/setec/types/api"
 	"github.com/tink-crypto/tink-go/v2/aead"
@@ -265,9 +264,7 @@ func (kv *kv) writeGen() uint64 {
 
 // list returns a list of all secret names in kv.
 func (kv *kv) list() []string {
-	ret := slices.Collect(maps.Keys(kv.secrets))
-	sort.Strings(ret)
-	return ret
+	return slices.Sorted(maps.Keys(kv.secrets))
 }
 
 // info returns metadata about a secret.

--- a/db/kv.go
+++ b/db/kv.go
@@ -10,11 +10,10 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"maps"
 	"os"
+	"slices"
 	"sort"
-
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 
 	"github.com/tailscale/setec/types/api"
 	"github.com/tink-crypto/tink-go/v2/aead"
@@ -266,7 +265,7 @@ func (kv *kv) writeGen() uint64 {
 
 // list returns a list of all secret names in kv.
 func (kv *kv) list() []string {
-	ret := maps.Keys(kv.secrets)
+	ret := slices.Collect(maps.Keys(kv.secrets))
 	sort.Strings(ret)
 	return ret
 }


### PR DESCRIPTION
Since we wrote this code, the maps and slices packages have been promoted to
mainline and expanded, so we no longer need to depend on x/exp for them.
