### PR TITLE
client/setec: update slices to mainline from x/exp

### DIFF
--- a/client/setec/fields.go
+++ b/client/setec/fields.go
@@ -11,9 +11,8 @@ import (
 	"fmt"
 	"path"
 	"reflect"
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/slices"
 )
 
 // ErrNoFields is a sentinel error reported by ParseFields when its argument is

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/tink-crypto/tink-go-awskms v0.0.0-20230616072154-ba4f9f22c3e9
 	github.com/tink-crypto/tink-go/v2 v2.1.0
-	golang.org/x/exp v0.0.0-20240416160154-fe59bbe5cc7f
 	golang.org/x/sync v0.7.0
 	golang.org/x/term v0.22.0
 	honnef.co/go/tools v0.5.1
@@ -99,6 +98,7 @@ require (
 	go4.org/mem v0.0.0-20220726221520-4f986261bf13 // indirect
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
 	golang.org/x/crypto v0.25.0 // indirect
+	golang.org/x/exp v0.0.0-20240416160154-fe59bbe5cc7f // indirect
 	golang.org/x/exp/typeparams v0.0.0-20240119083558-1b970713d09a // indirect
 	golang.org/x/mod v0.19.0 // indirect
 	golang.org/x/net v0.27.0 // indirect


### PR DESCRIPTION
Since we wrote this code, the maps and slices packages have been promoted to mainline and expanded, so we no longer need to depend on x/exp for them.

Follow up to #128 