### PR TITLE
Avoid busy-waiting between backups

### DIFF
--- a/server/backup.go
+++ b/server/backup.go
@@ -25,11 +25,11 @@ func (s *Server) periodicBackup(ctx context.Context) {
 			} else {
 				lastWriteGen = gen
 			}
-			select {
-			case <-time.After(time.Minute):
-			case <-ctx.Done():
-				return
-			}
+		}
+		select {
+		case <-time.After(time.Minute):
+		case <-ctx.Done():
+			return
 		}
 	}
 }


### PR DESCRIPTION
When S3 backups are enabled, setec uses 100% CPU, busy-waiting on DB updates.