### PR TITLE
acl: match ACL patterns without allocation

### DIFF
--- a/acl/acl.go
+++ b/acl/acl.go
@@ -7,11 +7,7 @@
 // ACL policies are provided by tailscale peer capabilities.
 package acl
 
-import (
-	"fmt"
-	"regexp"
-	"strings"
-)
+import "github.com/creachadair/mds/mstr"
 
 // Action is an action on secrets that is subject to access control.
 type Action string
@@ -45,27 +41,7 @@ const (
 type Secret string
 
 // Match reports whether the Secret name pattern matches val.
-func (pat Secret) Match(val string) bool {
-	s := string(pat)
-	if !strings.Contains(s, "*") && s == val {
-		return true
-	}
-	// We want the user to use glob-ish syntax, where '*' is the
-	// equivalent of regexp's '.*'. We also don't want any other
-	// character of the input misinterpreted as a regexp control
-	// character.
-	//
-	// To achieve this, we:
-	//  - split each input string on '*'
-	//  - regexp-quote the resulting parts
-	//  - reassemble the quoted parts around '.*' separators
-	parts := strings.Split(s, "*")
-	for i := range parts {
-		parts[i] = regexp.QuoteMeta(parts[i])
-	}
-	re := regexp.MustCompile(fmt.Sprintf("^%s$", strings.Join(parts, ".*")))
-	return re.MatchString(val)
-}
+func (pat Secret) Match(val string) bool { return mstr.Match(val, string(pat)) }
 
 // Rules is a set of ACLs for access to a secret.
 type Rules []Rule

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.13
 	github.com/creachadair/command v0.1.22
 	github.com/creachadair/flax v0.0.4
-	github.com/creachadair/mds v0.25.2
+	github.com/creachadair/mds v0.25.4
 	github.com/creachadair/msync v0.5.6
 	github.com/google/go-cmp v0.7.0
 	github.com/tink-crypto/tink-go-awskms v0.0.0-20230616072154-ba4f9f22c3e9

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/creachadair/command v0.1.22 h1:WmdrURwZdmPD1jm13SjKooaMoqo7mW1qI2BPCS
 github.com/creachadair/command v0.1.22/go.mod h1:YFc+OMGucqTpxwQg/iJnNg8BMNmRPDK60rYy8ckgKwE=
 github.com/creachadair/flax v0.0.4 h1:6JYUw/MK85Tw9f99n1PBBfLWYrxQkfrgWP4A6zf4XhE=
 github.com/creachadair/flax v0.0.4/go.mod h1:F1PML0JZLXSNDMNiRGK2yjm5f+L9QCHchyHBldFymj8=
-github.com/creachadair/mds v0.25.2 h1:xc0S0AfDq5GX9KUR5sLvi5XjA61/P6S5e0xFs1vA18Q=
-github.com/creachadair/mds v0.25.2/go.mod h1:+s4CFteFRj4eq2KcGHW8Wei3u9NyzSPzNV32EvjyK/Q=
+github.com/creachadair/mds v0.25.4 h1:rUQqf9ihePG8fhppXohLSY+AdOljU4oYyWVDhWiWhyE=
+github.com/creachadair/mds v0.25.4/go.mod h1:4hatI3hRM+qhzuAmqPRFvaBM8mONkS7nsLxkcuTYUIs=
 github.com/creachadair/msync v0.5.6 h1:nRvdyfVNNeMndcYDb+Ui8tSeefYXTUI1G7zPzosld6Q=
 github.com/creachadair/msync v0.5.6/go.mod h1:cHf8G0YBAfVk619K3RT7UARb8n6HAOCj0SZf4oUNkyM=
 github.com/creack/pty v1.1.23 h1:4M6+isWdcStXEf15G/RbrMPOQj1dZ7HPZCGwE4kOeP0=


### PR DESCRIPTION
An entirely optional diversion, but perhaps worthwhile.

While this is not an especially performance-sensitive area, this lets us get
rid of some regexp usage that wasn't necessary, and shrink the code. As a nice
side-effect, the replacement avoids any memory allocation at all.
