### PR TITLE
cmd/setec: disable SA4023 for build-tagged variants

### DIFF
--- a/cmd/setec/setec.go
+++ b/cmd/setec/setec.go
@@ -1,6 +1,8 @@
 // Copyright (c) Tailscale Inc & contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+//lint:file-ignore SA4023 Depends on build tag
+
 // Program setec is a secret management server that vends secrets over
 // Tailscale, and a client tool to communicate with that server.
 package main


### PR DESCRIPTION
On Darwin and other non-Linux platforms, the TPM key support complains that the
error check can never be false. Disable that check in this one case.
